### PR TITLE
hercules-ci-agent: Link C++ without g++ with -lstdc++

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent.cabal
+++ b/hercules-ci-agent/hercules-ci-agent.cabal
@@ -128,9 +128,10 @@ executable hercules-ci-agent-worker
   hs-source-dirs:
       hercules-ci-agent-worker
   default-extensions: DeriveGeneric DeriveTraversable DisambiguateRecordFields FlexibleContexts InstanceSigs LambdaCase MultiParamTypeClasses NoImplicitPrelude OverloadedStrings RankNTypes TupleSections TypeApplications TypeOperators
-  ghc-options: -Wall -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-name-shadowing -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N -pgmlg++
+  ghc-options: -Wall -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-name-shadowing -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
   -- GC_INCLUDE_NEW to use <new> header and standard C++ exception on OOM
   cc-options: -Wall -std=c++11
+  ld-options: -lstdc++
   include-dirs:
       cbits
   extra-libraries:


### PR DESCRIPTION
This works even if g++ is not on PATH.
Might even work on a non-GNU toolchain, but that may be
wishful thinking.