### PR TITLE
nix: Pick fixed dependencies instead of injecting sources via overlay

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,6 +6,5 @@ with
   { dev-overlay = self: pkgs:
       { inherit (import sources.niv {}) niv;
       };
-    sources-overlay = self: pkgs: { inherit sources; };
   };
-import nixpkgs { overlays = [ sources-overlay (import ./overlay.nix) dev-overlay ] ; config = {}; }
+import nixpkgs { overlays = [ (import ./overlay.nix) dev-overlay ] ; config = {}; }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,7 +13,8 @@ let
 
   inherit (pkgs.haskell.lib) overrideSrc;
 
-  inherit (pkgs.callPackage pkgs.sources.nix-gitignore {}) gitignoreFilterRecursiveSource;
+  gitignoreSource = (import ./sources.nix).nix-gitignore;
+  inherit (pkgs.callPackage gitignoreSource {}) gitignoreFilterRecursiveSource;
   gitignoreRecursiveSource = gitignoreFilterRecursiveSource (_: _: true);
   src = gitignoreRecursiveSource "" ../.;
 


### PR DESCRIPTION
Client injecting stuff like nix-gitignore is painful, unnecessary and
fragile - so we stop doing it.