### PR TITLE
tests/agent-test: Disable color

### DIFF
--- a/tests/agent-test/src/Main.hs
+++ b/tests/agent-test/src/Main.hs
@@ -13,7 +13,7 @@ main = do
   hSetBuffering stdout LineBuffering
   withTimeout $ withServer $ \server ->
     hspecWith config (beforeAll (pure server) Spec.spec)
-  where config = defaultConfig { configColorMode = ColorAlways }
+  where config = defaultConfig { configColorMode = ColorNever }
 
 withTimeout :: IO () -> IO ()
 withTimeout =


### PR DESCRIPTION
The color codes mess up the interleaved
output on the test VM log.