### PR TITLE
api: Move most of agent-specific modules into API/Agent

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent-worker/CNix/Internal/Typed.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/CNix/Internal/Typed.hs
@@ -44,25 +44,24 @@ data Match
 
 -- FIXME: errors don't provide any clue here
 match :: Ptr EvalState -> RawValue -> IO (Either SomeException Match)
-match es v =
-  forceValue es v >>= \case
-    Left e -> pure (Left e)
-    Right _ -> rawValueType v <&> \case
-      Int -> pure $ IsInt $ unsafeAssertType v
-      Bool -> pure $ IsBool $ unsafeAssertType v
-      String -> pure $ IsString $ unsafeAssertType v
-      Path -> pure $ IsPath $ unsafeAssertType v
-      Null -> pure $ IsNull $ unsafeAssertType v
-      Attrs -> pure $ IsAttrs $ unsafeAssertType v
-      List -> pure $ IsList $ unsafeAssertType v
-      Thunk -> Left $ SomeException $ userError "Could not force Nix thunk" -- FIXME: custom exception?
-      App -> Left $ SomeException $ userError "Could not force Nix thunk (App)"
-      Blackhole ->
-        Left $ SomeException $ userError "Could not force Nix thunk (Blackhole)"
-      Lambda -> pure $ IsFunction $ unsafeAssertType v
-      PrimOp -> pure $ IsFunction $ unsafeAssertType v
-      PrimOpApp -> pure $ IsFunction $ unsafeAssertType v
-      External -> pure $ IsExternal $ unsafeAssertType v
-      Float -> pure $ IsFloat $ unsafeAssertType v
-      Other ->
-        Left $ SomeException $ userError "Unknown runtime type in Nix value"
+match es v = forceValue es v >>= \case
+  Left e -> pure (Left e)
+  Right _ -> rawValueType v <&> \case
+    Int -> pure $ IsInt $ unsafeAssertType v
+    Bool -> pure $ IsBool $ unsafeAssertType v
+    String -> pure $ IsString $ unsafeAssertType v
+    Path -> pure $ IsPath $ unsafeAssertType v
+    Null -> pure $ IsNull $ unsafeAssertType v
+    Attrs -> pure $ IsAttrs $ unsafeAssertType v
+    List -> pure $ IsList $ unsafeAssertType v
+    Thunk -> Left $ SomeException $ userError "Could not force Nix thunk" -- FIXME: custom exception?
+    App -> Left $ SomeException $ userError "Could not force Nix thunk (App)"
+    Blackhole ->
+      Left $ SomeException $ userError "Could not force Nix thunk (Blackhole)"
+    Lambda -> pure $ IsFunction $ unsafeAssertType v
+    PrimOp -> pure $ IsFunction $ unsafeAssertType v
+    PrimOpApp -> pure $ IsFunction $ unsafeAssertType v
+    External -> pure $ IsExternal $ unsafeAssertType v
+    Float -> pure $ IsFloat $ unsafeAssertType v
+    Other ->
+      Left $ SomeException $ userError "Unknown runtime type in Nix value"

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
@@ -101,11 +101,10 @@ runEval eval = do
         $ evalArgs evalState (autoArgArgs (Eval.autoArguments eval))
 
       Data.Conduit.handleC
-          (\e ->
-            yield $ Event.AttributeError $ AttributeError.AttributeError
-              { AttributeError.path = []
-              , AttributeError.message = renderException e
-              }
+          (\e -> yield $ Event.AttributeError $ AttributeError.AttributeError
+            { AttributeError.path = []
+            , AttributeError.message = renderException e
+            }
           )
         $ do
             imprt <- liftIO $ evalFile evalState (toS $ Eval.file eval)
@@ -122,11 +121,10 @@ walk :: Ptr EvalState
 walk evalState = walk' True [] 10
  where
   handleErrors path = Data.Conduit.handleC
-    (\e ->
-      yield $ Event.AttributeError $ AttributeError.AttributeError
-        { AttributeError.path = path
-        , AttributeError.message = renderException e
-        }
+    (\e -> yield $ Event.AttributeError $ AttributeError.AttributeError
+      { AttributeError.path = path
+      , AttributeError.message = renderException e
+      }
     )
 
   walk' :: Bool                -- ^ If True, always walk this attribute set. Only True for the root.
@@ -137,61 +135,64 @@ walk evalState = walk' True [] 10
         -> ConduitT i1 Event (ResourceT IO) () -- ^ Program that performs the walk and emits 'Event's
   walk' forceWalkAttrset path depthRemaining autoArgs v =
     -- liftIO $ hPutStrLn stderr $ "Walking " <> (show path :: Text)
-    handleErrors path $
-      liftIO (match evalState v) >>= \case
-        Left e -> yield $ Event.AttributeError $ AttributeError.AttributeError
-          { AttributeError.path = path
-          , AttributeError.message = renderException e
-          }
-        Right m -> case m of
-          IsAttrs attrValue -> do
-            isDeriv <- liftIO $ isDerivation evalState v
-            if isDeriv
-              then do
-                drvPath <- getDrvFile evalState v
-                yield $ Event.Attribute Attribute.Attribute
-                  { Attribute.path = path
-                  , Attribute.drv = drvPath
-                  }
-              else do
-                walkAttrset <- if forceWalkAttrset
-                  then pure True
-                  else
+    handleErrors path
+      $ liftIO (match evalState v)
+      >>= \case
+            Left e ->
+              yield $ Event.AttributeError $ AttributeError.AttributeError
+                { AttributeError.path = path
+                , AttributeError.message = renderException e
+                }
+            Right m -> case m of
+              IsAttrs attrValue -> do
+                isDeriv <- liftIO $ isDerivation evalState v
+                if isDeriv
+                  then do
+                    drvPath <- getDrvFile evalState v
+                    yield $ Event.Attribute Attribute.Attribute
+                      { Attribute.path = path
+                      , Attribute.drv = drvPath
+                      }
+                  else do
+                    walkAttrset <- if forceWalkAttrset
+                      then pure True
+                      else
 -- Hydra doesn't seem to obey this, because it walks the
 -- x64_64-linux etc attributes per package. Maybe those
 -- are special cases?
 -- For now, we will assume that people don't build a whole Nixpkgs
-                       liftIO $ getRecurseForDerivations evalState attrValue
+                           liftIO $ getRecurseForDerivations evalState attrValue
 
-                isfunctor <- liftIO $ isFunctor evalState v
-                if isfunctor && walkAttrset
-                  then do
-                    x <- liftIO (autoCallFunction evalState v autoArgs)
-                    walk' True path (depthRemaining - 1) autoArgs x
-                  else do
-                    attrs <- liftIO $ getAttrs attrValue
+                    isfunctor <- liftIO $ isFunctor evalState v
+                    if isfunctor && walkAttrset
+                      then do
+                        x <- liftIO (autoCallFunction evalState v autoArgs)
+                        walk' True path (depthRemaining - 1) autoArgs x
+                      else do
+                        attrs <- liftIO $ getAttrs attrValue
 
-                    void
-                      $ flip M.traverseWithKey attrs
-                      $ \name value ->
-                          when (depthRemaining > 0 && walkAttrset) $ -- TODO: else warn
-                            walk' False
-                                  (path ++ [name])
-                                  (depthRemaining - 1)
-                                  autoArgs
-                                  value
+                        void
+                          $ flip M.traverseWithKey attrs
+                          $ \name value ->
+                              when (depthRemaining > 0 && walkAttrset) $ -- TODO: else warn
+                                                                         walk'
+                                False
+                                (path ++ [name])
+                                (depthRemaining - 1)
+                                autoArgs
+                                value
 
-          _any -> liftIO $ do
-            vt <- rawValueType v
-            unless
-                  (last path
-                  == "recurseForDerivations"
-                  && vt
-                  == CNix.Internal.Raw.Bool
-                  )
-              $ hPutStrLn stderr
-                    $ "Ignoring "
-                    <> show path
-                    <> " : "
-                    <> (show vt :: Text)
-            pass
+              _any -> liftIO $ do
+                vt <- rawValueType v
+                unless
+                    (last path
+                    == "recurseForDerivations"
+                    && vt
+                    == CNix.Internal.Raw.Bool
+                    )
+                  $ hPutStrLn stderr
+                  $ "Ignoring "
+                  <> show path
+                  <> " : "
+                  <> (show vt :: Text)
+                pass

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
@@ -12,15 +12,15 @@ import           Control.Concurrent.Async.Lifted
                                                 ( replicateConcurrently_ )
 import           Control.Concurrent.MVar.Lifted ( withMVar )
 
-import           Hercules.API                   ( noContent
-                                                )
-import           Hercules.API.Agent.Tasks                   ( tasksReady
+import           Hercules.API                   ( noContent )
+import           Hercules.API.Agent.Tasks       ( tasksReady
                                                 , tasksSetStatus
                                                 )
 import           Hercules.API.Task              ( Task )
 import qualified Hercules.API.Task             as Task
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
 import qualified Hercules.API.Agent.Build.BuildTask
                                                as BuildTask
 import           Hercules.Agent.Client          ( tasksClient )
@@ -88,10 +88,12 @@ performTask task =
     $ safeLiftedHandle
         (\e -> do
           logLocM ErrorS $ "Exception in task: " <> show (e :: SomeException)
-          retry (cap 60 exponential) $ noContent $ runHerculesClient $
-            tasksSetStatus tasksClient
-                                        (Task.id task)
-                                        (TaskStatus.Exceptional $ show e)
+          retry (cap 60 exponential)
+            $ noContent
+            $ runHerculesClient
+            $ tasksSetStatus tasksClient
+                             (Task.id task)
+                             (TaskStatus.Exceptional $ show e)
         )
     $ do
         logLocM InfoS "Starting task"
@@ -109,7 +111,7 @@ performTask task =
 
         logLocM InfoS "Completed task successfully"
 
-        noContent $ runHerculesClient $
-          tasksSetStatus tasksClient
-                                      (Task.id task)
-                                      (TaskStatus.Successful ())
+        noContent $ runHerculesClient $ tasksSetStatus
+          tasksClient
+          (Task.id task)
+          (TaskStatus.Successful ())

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
@@ -12,14 +12,15 @@ import           Control.Concurrent.Async.Lifted
                                                 ( replicateConcurrently_ )
 import           Control.Concurrent.MVar.Lifted ( withMVar )
 
-import           Hercules.API                   ( tasksReady
+import           Hercules.API                   ( noContent
+                                                )
+import           Hercules.API.Agent.Tasks                   ( tasksReady
                                                 , tasksSetStatus
-                                                , noContent
                                                 )
 import           Hercules.API.Task              ( Task )
 import qualified Hercules.API.Task             as Task
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
 import qualified Hercules.API.Agent.Build.BuildTask
                                                as BuildTask
 import           Hercules.Agent.Client          ( tasksClient )
@@ -76,7 +77,7 @@ main = Init.setupLogging $ \logEnv -> do
               x -> pure x
             )
           $ Env.runHerculesClient
-          $ Hercules.API.tasksReady tasksClient
+          $ tasksReady tasksClient
 
         forM_ taskMaybe $ performTask
 
@@ -88,7 +89,7 @@ performTask task =
         (\e -> do
           logLocM ErrorS $ "Exception in task: " <> show (e :: SomeException)
           retry (cap 60 exponential) $ noContent $ runHerculesClient $
-            Hercules.API.tasksSetStatus tasksClient
+            tasksSetStatus tasksClient
                                         (Task.id task)
                                         (TaskStatus.Exceptional $ show e)
         )
@@ -109,6 +110,6 @@ performTask task =
         logLocM InfoS "Completed task successfully"
 
         noContent $ runHerculesClient $
-          Hercules.API.tasksSetStatus tasksClient
+          tasksSetStatus tasksClient
                                       (Task.id task)
                                       (TaskStatus.Successful ())

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
@@ -43,8 +43,8 @@ performBuild task = do
 
   logLocM DebugS $ "Invoking nix-store: " <> show procSpec
 
-  (status, _out, errBytes) <- liftIO $
-    sourceProcessWithStreams procSpec stdinc stdoutc stderrc
+  (status, _out, errBytes) <- liftIO
+    $ sourceProcessWithStreams procSpec stdinc stdoutc stderrc
 
   withNamedContext "exitStatus" (show status :: Text)
     $ logLocM DebugS

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/CabalInfo.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/CabalInfo.hs
@@ -2,7 +2,7 @@ module Hercules.Agent.CabalInfo where
 
 import           Data.Version                   ( showVersion )
 import           Protolude
-import           Paths_hercules_ci_agent           ( version )
+import           Paths_hercules_ci_agent        ( version )
 
 herculesAgentVersion :: Text
 herculesAgentVersion = toS (showVersion version)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Client.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Client.hs
@@ -14,8 +14,6 @@ import           Servant.API.Generic            ( fromServant )
 import           Servant.Auth.Client            ( )
 import           Servant.Client.Generic         ( AsClientT )
 import           Hercules.API                   ( HerculesAPI
-                                                , TasksAPI
-                                                , EvalAPI
                                                 , ClientAuth
                                                 , servantApi
                                                 , eval
@@ -25,6 +23,8 @@ import           Hercules.API                   ( HerculesAPI
                                                 , useApi
                                                 )
 import           Hercules.API.Agent.Build       ( BuildAPI )
+import           Hercules.API.Agent.Evaluate ( EvalAPI )
+import           Hercules.API.Agent.Tasks ( TasksAPI )
 import qualified Hercules.API.Agents
 
 client :: HerculesAPI ClientAuth (AsClientT ClientM)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Client.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Client.hs
@@ -23,8 +23,8 @@ import           Hercules.API                   ( HerculesAPI
                                                 , useApi
                                                 )
 import           Hercules.API.Agent.Build       ( BuildAPI )
-import           Hercules.API.Agent.Evaluate ( EvalAPI )
-import           Hercules.API.Agent.Tasks ( TasksAPI )
+import           Hercules.API.Agent.Evaluate    ( EvalAPI )
+import           Hercules.API.Agent.Tasks       ( TasksAPI )
 import qualified Hercules.API.Agents
 
 client :: HerculesAPI ClientAuth (AsClientT ClientM)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
@@ -29,7 +29,6 @@ defaultApiBaseUrl :: Text
 defaultApiBaseUrl = "https://hercules-ci.com"
 
 readConfig :: Maybe Text -> IO Config
-readConfig loc =
-  case loc of
-    Just x -> Dhall.input Dhall.auto $ toS x
-    Nothing -> newDefaultConfig
+readConfig loc = case loc of
+  Just x -> Dhall.input Dhall.auto $ toS x
+  Nothing -> newDefaultConfig

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Evaluate.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Evaluate.hs
@@ -31,17 +31,19 @@ import qualified Hercules.Agent.WorkerProtocol.Command
                                                as Command
 import qualified Hercules.Agent.WorkerProtocol.Command.Eval
                                                as Eval
-import           Hercules.API                   ( tasksUpdateEvaluation
+import           Hercules.API                   ( noContent
+                                                )
+import           Hercules.API.Agent.Evaluate                   ( tasksUpdateEvaluation
                                                 , tasksGetEvaluation
-                                                , noContent
+
                                                 )
 import           Hercules.API.Task              ( Task )
 import qualified Hercules.API.Task             as Task
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
-import qualified Hercules.API.EvaluateEvent    as EvaluateEvent
-import qualified Hercules.API.EvaluateEvent.AttributeEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent    as EvaluateEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent
                                                as AttributeEvent
-import qualified Hercules.API.EvaluateEvent.AttributeErrorEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent
                                                as AttributeErrorEvent
 import qualified Hercules.API.Message          as Message
 import qualified Network.HTTP.Client.Conduit   as HTTP.Conduit
@@ -102,7 +104,7 @@ performEvaluation task' = do
   eventChan <- liftIO $ newChan
   let submitBatch events =
         unlift $ noContent $ defaultRetry $ runHerculesClient
-          (Hercules.API.tasksUpdateEvaluation
+          (tasksUpdateEvaluation
             Hercules.Agent.Client.evalClient
             (EvaluateTask.id task)
             events

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Exception.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Exception.hs
@@ -6,7 +6,7 @@ import qualified Control.Exception.Safe
 import           Control.Monad.Trans.Control    ( MonadBaseControl )
 import qualified Control.Exception.Lifted
 import           Katip
-import           Katip.Monadic (logLocM)
+import           Katip.Monadic                  ( logLocM )
 
 safeLiftedCatch :: MonadBaseControl IO m => m a -> (SomeException -> m a) -> m a
 safeLiftedCatch m h =
@@ -34,12 +34,11 @@ retry :: (KatipContext m, MonadBaseControl IO m)
 retry delaysSeconds io = loop delaysSeconds
  where
   loop [] = io
-  loop (delay : delays) =
-    safeLiftedCatch io $ \e -> do
-      logLocM WarningS $ "Retrying on exception: " <> logStr (show e :: Text)
-      when (delay >= 0.000001) $ liftIO $ threadDelay
-        (floor $ delay * 1000 * 1000)
-      loop delays
+  loop (delay : delays) = safeLiftedCatch io $ \e -> do
+    logLocM WarningS $ "Retrying on exception: " <> logStr (show e :: Text)
+    when (delay >= 0.000001) $ liftIO $ threadDelay
+      (floor $ delay * 1000 * 1000)
+    loop delays
 
 -- | 5 minute exponential backoff
 defaultRetry :: (KatipContext m, MonadBaseControl IO m) => m a -> m a

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Log.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Log.hs
@@ -11,9 +11,9 @@ where
 import           Protolude
 
 import           Data.Aeson
-import           Katip hiding (logLocM)
+import           Katip                   hiding ( logLocM )
 import           Katip.Core
-import           Katip.Monadic (logLocM)
+import           Katip.Monadic                  ( logLocM )
 
 instance StringConv [Char] LogStr where
   strConv l = logStr . (strConv l :: [Char] -> Text)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/NixPath.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/NixPath.hs
@@ -7,7 +7,8 @@ where
 
 import           Protolude
 import qualified Data.Text                     as T
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
 
 renderNixPath :: [EvaluateTask.NixPathElement (EvaluateTask.SubPathOf FilePath)]
               -> Text

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/NixPath.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/NixPath.hs
@@ -7,7 +7,7 @@ where
 
 import           Protolude
 import qualified Data.Text                     as T
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
 
 renderNixPath :: [EvaluateTask.NixPathElement (EvaluateTask.SubPathOf FilePath)]
               -> Text

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Scribe.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Scribe.hs
@@ -17,6 +17,7 @@ import           Hercules.Agent.Env             ( App
 import           Hercules.Agent.Client          ( tasksClient )
 import           Hercules.Agent.Batch
 import           Hercules.API
+import           Hercules.API.Agent.Tasks
 import           Katip
 
 withHerculesScribe :: App a -> App a

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
@@ -17,9 +17,9 @@ import           Hercules.Agent.CabalInfo      as CabalInfo
 import           Hercules.Agent.Log
 
 getDataDirectory :: MonadIO m => m FilePath
-getDataDirectory =
-  liftIO $ System.Directory.getXdgDirectory System.Directory.XdgData
-                                            "hercules-ci-agent"
+getDataDirectory = liftIO $ System.Directory.getXdgDirectory
+  System.Directory.XdgData
+  "hercules-ci-agent"
 
 writeAgentSessionKey :: Text -> App ()
 writeAgentSessionKey tok = do
@@ -29,8 +29,7 @@ writeAgentSessionKey tok = do
 
 -- | Reads a token file, strips whitespace
 readTokenFile :: MonadIO m => FilePath -> m Text
-readTokenFile fp =
-  liftIO $ sanitize <$> readFile fp
+readTokenFile fp = liftIO $ sanitize <$> readFile fp
  where
   sanitize = T.map subst . T.strip
   subst '\n' = ' '
@@ -50,25 +49,24 @@ readAgentSessionKey = do
     False -> pure Nothing
 
 ensureAgentSession :: App Text
-ensureAgentSession =
-  readAgentSessionKey >>= \case
-    Just x -> do
-      logLocM DebugS "Found agent session key"
-      pure x
-    Nothing -> do
-      writeAgentSessionKey "x" -- Sanity check
-      logLocM DebugS "Creating agent session"
-      agentSessionKey <- createAgentSession
-      logLocM DebugS "Agent session key acquired"
-      writeAgentSessionKey agentSessionKey
-      logLocM DebugS "Agent session key persisted"
-      readAgentSessionKey >>= \case
-        Just x -> do
-          logLocM DebugS "Found the new agent session"
-          pure x
-        Nothing ->
-          panic
-            "The file session.key seems to have disappeared. Refusing to continue."
+ensureAgentSession = readAgentSessionKey >>= \case
+  Just x -> do
+    logLocM DebugS "Found agent session key"
+    pure x
+  Nothing -> do
+    writeAgentSessionKey "x" -- Sanity check
+    logLocM DebugS "Creating agent session"
+    agentSessionKey <- createAgentSession
+    logLocM DebugS "Agent session key acquired"
+    writeAgentSessionKey agentSessionKey
+    logLocM DebugS "Agent session key persisted"
+    readAgentSessionKey >>= \case
+      Just x -> do
+        logLocM DebugS "Found the new agent session"
+        pure x
+      Nothing ->
+        panic
+          "The file session.key seems to have disappeared. Refusing to continue."
 
 createAgentSession :: App Text
 createAgentSession = do
@@ -82,8 +80,9 @@ createAgentSession = do
 
   logLocM DebugS $ "CreateAgent data: " <> show createAgentBody
   token <- asks Env.currentToken
-  runHerculesClient'
-    $ Hercules.API.Agents.agentSessionCreate agentsClient createAgentBody token
+  runHerculesClient' $ Hercules.API.Agents.agentSessionCreate agentsClient
+                                                              createAgentBody
+                                                              token
 
 -- TODO: Although this looks nice, the implicit limitation here is that we can
 --       only have one token at a time. I wouldn't be surprised if this becomes

--- a/hercules-ci-agent/hercules-ci-agent/WorkerProcess.hs
+++ b/hercules-ci-agent/hercules-ci-agent/WorkerProcess.hs
@@ -47,8 +47,8 @@ runWorker baseProcess stderrSink interaction = do
             .| concatMapC (\x -> [Chunk x, Flush])
             .| sinkHandleFlush inHandle
 
-    let interactor = runConduit $
-          interaction eventSource `fuseUpstream` commandSink
+    let interactor =
+          runConduit $ interaction eventSource `fuseUpstream` commandSink
 
     r <- runConcurrently (Concurrently stderrPiper *> Concurrently interactor)
     e <- waitForProcess processHandle

--- a/hercules-ci-agent/test/Hercules/Agent/NixPathSpec.hs
+++ b/hercules-ci-agent/test/Hercules/Agent/NixPathSpec.hs
@@ -4,7 +4,7 @@ module Hercules.Agent.NixPathSpec where
 import           Protolude
 import           Test.Hspec
 import           Hercules.Agent.NixPath
-import           Hercules.API.EvaluateTask
+import           Hercules.API.Agent.Evaluate.EvaluateTask
 
 spec :: Spec
 spec = do

--- a/hercules-ci-agent/test/Spec.hs
+++ b/hercules-ci-agent/test/Spec.hs
@@ -1,6 +1,6 @@
 module Spec
-    ( spec
-    )
+  ( spec
+  )
 where
 
 import           Test.Hspec
@@ -8,4 +8,4 @@ import qualified Hercules.Agent.NixPathSpec
 
 spec :: Spec
 spec = do
-    describe "Hercules.Agent.NixPathSpec" Hercules.Agent.NixPathSpec.spec
+  describe "Hercules.Agent.NixPathSpec" Hercules.Agent.NixPathSpec.spec

--- a/hercules-ci-api/hercules-ci-api.cabal
+++ b/hercules-ci-api/hercules-ci-api.cabal
@@ -24,6 +24,12 @@ library
       Hercules.API.Agent.Build
       Hercules.API.Agent.Build.BuildEvent
       Hercules.API.Agent.Build.BuildTask
+      Hercules.API.Agent.Evaluate
+      Hercules.API.Agent.Evaluate.EvaluateEvent
+      Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent
+      Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent
+      Hercules.API.Agent.Evaluate.EvaluateTask
+      Hercules.API.Agent.Tasks
       Hercules.API.Agents
       Hercules.API.Agents.AgentSession
       Hercules.API.Agents.AgentSessionCreated
@@ -31,16 +37,11 @@ library
       Hercules.API.Agents.CreateAgentSession
       Hercules.API.Agents.CreateClusterJoinToken
       Hercules.API.Agents.FullClusterJoinToken
-      Hercules.API.AgentTask
       Hercules.API.Attribute
       Hercules.API.Auth
       Hercules.API.Build
       Hercules.API.Build.EvaluationDetail
       Hercules.API.Derivation
-      Hercules.API.EvaluateEvent
-      Hercules.API.EvaluateEvent.AttributeErrorEvent
-      Hercules.API.EvaluateEvent.AttributeEvent
-      Hercules.API.EvaluateTask
       Hercules.API.Evaluation.Evaluation
       Hercules.API.Id
       Hercules.API.Message

--- a/hercules-ci-api/src/Hercules/API.hs
+++ b/hercules-ci-api/src/Hercules/API.hs
@@ -46,11 +46,11 @@ import           Hercules.API.Agent.Build      as Agent
                                                 ( BuildAPI )
 import           Hercules.API.Agent.Evaluate   as Agent
                                                 ( EvalAPI )
-import           Hercules.API.Agent.Tasks   as Agent
+import           Hercules.API.Agent.Tasks      as Agent
                                                 ( TasksAPI )
 import           Hercules.API.Build            as Client
                                                 ( BuildAPI )
-import           Hercules.API.Result            (Result(..))
+import           Hercules.API.Result            ( Result(..) )
 
 data HerculesAPI auth f = HerculesAPI
    { accounts :: f :- ToServantApi (AccountsAPI auth)

--- a/hercules-ci-api/src/Hercules/API.hs
+++ b/hercules-ci-api/src/Hercules/API.hs
@@ -10,8 +10,6 @@ module Hercules.API
   , ClientAuth
   , HerculesAPI(..)
   , HerculesServantAPI
-  , TasksAPI(..)
-  , EvalAPI(..)
   , AddAPIVersion
   , Id
   , Name
@@ -26,38 +24,33 @@ module Hercules.API
 where
 
 import           Prelude
+
 import           Control.Lens
 import           Control.Monad
-import           Data.Aeson                     ( Object )
 import           Data.Proxy                     ( Proxy(..) )
 import           Data.Swagger            hiding ( Header )
-import           Data.Text                      ( Text )
 import           GHC.Generics                   ( Generic )
+import           Hercules.API.Accounts          ( AccountsAPI )
+import           Hercules.API.Agents            ( AgentsAPI )
+import           Hercules.API.Id                ( Id )
+import           Hercules.API.Name              ( Name )
+import           Hercules.API.Projects          ( ProjectsAPI )
+import           Hercules.API.Repos             ( ReposAPI )
 import           Servant.API
 import           Servant.API.Generic
 import           Servant.Auth
 import           Servant.Auth.Swagger           ( )
 import           Servant.Swagger
 import           Servant.Swagger.UI.Core        ( SwaggerSchemaUI )
-import           Hercules.API.Id                ( Id )
-import           Hercules.API.Name              ( Name )
-import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
-import qualified Hercules.API.EvaluateEvent    as EvaluateEvent
-import qualified Hercules.API.Task             as Task
-import           Hercules.API.Attribute         ( Attribute )
-import           Hercules.API.Message           ( Message )
-import           Hercules.API.Result            ( Result(..) )
-import           Hercules.API.Derivation        ( DerivationPath )
-
-import           Hercules.API.Accounts          ( AccountsAPI )
-import           Hercules.API.Repos             ( ReposAPI )
-import           Hercules.API.Projects          ( ProjectsAPI )
-import           Hercules.API.Agents            ( AgentsAPI )
 import           Hercules.API.Agent.Build      as Agent
                                                 ( BuildAPI )
+import           Hercules.API.Agent.Evaluate   as Agent
+                                                ( EvalAPI )
+import           Hercules.API.Agent.Tasks   as Agent
+                                                ( TasksAPI )
 import           Hercules.API.Build            as Client
                                                 ( BuildAPI )
+import           Hercules.API.Result            (Result(..))
 
 data HerculesAPI auth f = HerculesAPI
    { accounts :: f :- ToServantApi (AccountsAPI auth)
@@ -76,57 +69,6 @@ data ClientAPI auth f = ClientAPI
    , clientProjects :: f :- ToServantApi (ProjectsAPI auth)
    , clientAgents :: f :- ToServantApi (AgentsAPI auth)
    , clientBuild :: f :- ToServantApi (Client.BuildAPI auth)
-   } deriving Generic
-
--- TODO: add type parameter to specify types of corecord instead of
--- @Task.Task Task.Any@.
-data TasksAPI auth f = TasksAPI
-   { tasksReady :: f :-
-       "tasks" :>
-       auth :>
-       Post '[JSON] (Maybe (Task.Task Task.Any))
-   , tasksSetStatus :: f :-
-       "tasks" :>
-       Capture "taskId" (Id (Task.Task Task.Any)) :>
-       ReqBody '[JSON] TaskStatus.TaskStatus :>
-       auth :>
-       Post '[JSON] NoContent
-   , postLog :: f :-
-       "tasks" :>
-       "log" :>
-       ReqBody '[JSON] [Object] :>
-       auth :>
-       Post '[JSON] NoContent
-   } deriving Generic
-
-data EvalAPI auth f = EvalAPI
-   { tasksGetEvaluation :: f :-
-       "tasks" :>
-       Capture "taskId" (Id (Task.Task EvaluateTask.EvaluateTask)) :>
-       "eval" :>
-       auth :>
-       Get '[JSON] EvaluateTask.EvaluateTask
-   , tasksUpdateEvaluation :: f :-
-       "tasks" :>
-       Capture "taskId" (Id (Task.Task EvaluateTask.EvaluateTask)) :>
-       "eval" :>
-       ReqBody '[JSON] [EvaluateEvent.EvaluateEvent] :>
-       auth :>
-       Post '[JSON] NoContent
-   , tasksPreviewAttrs :: f :-
-       "tasks" :>
-       Capture "taskId" (Id (Task.Task EvaluateTask.EvaluateTask)) :>
-       "eval" :>
-       "attributes" :>
-       auth :>
-       Get '[JSON] [Attribute (Result Text DerivationPath)]
-   , tasksPreviewMessages :: f :-
-       "tasks" :>
-       Capture "evaluationId" (Id (Task.Task EvaluateTask.EvaluateTask)) :>
-       "eval" :>
-       "messages" :>
-       auth :>
-       Get '[JSON] [Message]
    } deriving Generic
 
 type ClientAuth = Auth '[JWT, Cookie] ()

--- a/hercules-ci-api/src/Hercules/API/Agent/AgentTask.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/AgentTask.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE DeriveAnyClass #-}
+module AgentTask where
+
+import           Hercules.API.Prelude
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+
+data AgentTask = Evaluate EvaluateTask.EvaluateTask
+               | Build Text
+  deriving (Generic, Show, Eq, ToJSON, FromJSON, ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Agent/AgentTask.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/AgentTask.hs
@@ -2,7 +2,8 @@
 module AgentTask where
 
 import           Hercules.API.Prelude
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
 
 data AgentTask = Evaluate EvaluateTask.EvaluateTask
                | Build Text

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+module Hercules.API.Agent.Evaluate where
+
+import Hercules.API.Prelude
+
+import Hercules.API.Agent.Evaluate.EvaluateEvent (EvaluateEvent)
+import Hercules.API.Agent.Evaluate.EvaluateTask (EvaluateTask)
+import Hercules.API.Attribute (Attribute)
+import Hercules.API.Derivation (DerivationPath)
+import Hercules.API.Message (Message)
+import Hercules.API.Result (Result)
+import Hercules.API.Task (Task)
+import Servant.API
+import Servant.API.Generic
+
+data EvalAPI auth f = EvalAPI
+ { tasksGetEvaluation :: f :-
+    "tasks" :>
+    Capture "taskId" (Id (Task EvaluateTask)) :>
+    "eval" :>
+    auth :>
+    Get '[JSON] EvaluateTask
+
+ , tasksUpdateEvaluation :: f :-
+    "tasks" :>
+    Capture "taskId" (Id (Task EvaluateTask)) :>
+    "eval" :>
+    ReqBody '[JSON] [EvaluateEvent] :>
+    auth :>
+    Post '[JSON] NoContent
+
+    -- TODO: Remove
+ , tasksPreviewAttrs :: f :-
+    "tasks" :>
+    Capture "taskId" (Id (Task EvaluateTask)) :>
+    "eval" :>
+    "attributes" :>
+    auth :>
+    Get '[JSON] [Attribute (Result Text DerivationPath)]
+
+    -- TODO: Remove
+ , tasksPreviewMessages :: f :-
+    "tasks" :>
+    Capture "evaluationId" (Id (Task EvaluateTask)) :>
+    "eval" :>
+    "messages" :>
+    auth :>
+    Get '[JSON] [Message]
+ } deriving Generic

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate.hs
@@ -1,17 +1,19 @@
 {-# LANGUAGE DataKinds #-}
 module Hercules.API.Agent.Evaluate where
 
-import Hercules.API.Prelude
+import           Hercules.API.Prelude
 
-import Hercules.API.Agent.Evaluate.EvaluateEvent (EvaluateEvent)
-import Hercules.API.Agent.Evaluate.EvaluateTask (EvaluateTask)
-import Hercules.API.Attribute (Attribute)
-import Hercules.API.Derivation (DerivationPath)
-import Hercules.API.Message (Message)
-import Hercules.API.Result (Result)
-import Hercules.API.Task (Task)
-import Servant.API
-import Servant.API.Generic
+import           Hercules.API.Agent.Evaluate.EvaluateEvent
+                                                ( EvaluateEvent )
+import           Hercules.API.Agent.Evaluate.EvaluateTask
+                                                ( EvaluateTask )
+import           Hercules.API.Attribute         ( Attribute )
+import           Hercules.API.Derivation        ( DerivationPath )
+import           Hercules.API.Message           ( Message )
+import           Hercules.API.Result            ( Result )
+import           Hercules.API.Task              ( Task )
+import           Servant.API
+import           Servant.API.Generic
 
 data EvalAPI auth f = EvalAPI
  { tasksGetEvaluation :: f :-

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
-module Hercules.API.EvaluateEvent where
+module Hercules.API.Agent.Evaluate.EvaluateEvent where
 
 import           Prelude
 import           GHC.Generics                   ( Generic )
@@ -7,9 +7,9 @@ import           Data.Aeson                     ( ToJSON
                                                 , FromJSON
                                                 )
 import           Data.Swagger                   ( ToSchema )
-import qualified Hercules.API.EvaluateEvent.AttributeEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent
                                                as AttributeEvent
-import qualified Hercules.API.EvaluateEvent.AttributeErrorEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent
                                                as AttributeErrorEvent
 import qualified Hercules.API.Message          as Message
 

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent/AttributeErrorEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent/AttributeErrorEvent.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE ConstraintKinds #-}
-module Hercules.API.EvaluateEvent.AttributeErrorEvent where
+module Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent where
 
 import           Prelude
 import           Data.Text                      ( Text )

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent/AttributeEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateEvent/AttributeEvent.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE ConstraintKinds #-}
-module Hercules.API.EvaluateEvent.AttributeEvent where
+module Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent where
 
 import           Prelude
 import           Data.Text                      ( Text )

--- a/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateTask.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Evaluate/EvaluateTask.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveAnyClass #-}
-module Hercules.API.EvaluateTask where
+module Hercules.API.Agent.Evaluate.EvaluateTask where
 
 import           Prelude
 import           Data.Text                      ( Text )

--- a/hercules-ci-api/src/Hercules/API/Agent/Tasks.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Tasks.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 module Hercules.API.Agent.Tasks where
 
-import Hercules.API.Prelude
-import Data.Aeson(Object)
-import Hercules.API.TaskStatus
-import qualified Hercules.API.Task as Task
-import Servant.API
-import Servant.API.Generic
+import           Hercules.API.Prelude
+import           Data.Aeson                     ( Object )
+import           Hercules.API.TaskStatus
+import qualified Hercules.API.Task             as Task
+import           Servant.API
+import           Servant.API.Generic
 
 data TasksAPI auth f = TasksAPI
    { tasksReady :: f :-

--- a/hercules-ci-api/src/Hercules/API/Agent/Tasks.hs
+++ b/hercules-ci-api/src/Hercules/API/Agent/Tasks.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+module Hercules.API.Agent.Tasks where
+
+import Hercules.API.Prelude
+import Data.Aeson(Object)
+import Hercules.API.TaskStatus
+import qualified Hercules.API.Task as Task
+import Servant.API
+import Servant.API.Generic
+
+data TasksAPI auth f = TasksAPI
+   { tasksReady :: f :-
+       "tasks" :>
+       auth :>
+       Post '[JSON] (Maybe (Task.Task Task.Any))
+   , tasksSetStatus :: f :-
+       "tasks" :>
+       Capture "taskId" (Id (Task.Task Task.Any)) :>
+       ReqBody '[JSON] TaskStatus :>
+       auth :>
+       Post '[JSON] NoContent
+   , postLog :: f :-
+       "tasks" :>
+       "log" :>
+       ReqBody '[JSON] [Object] :>
+       auth :>
+       Post '[JSON] NoContent
+   } deriving Generic
+

--- a/hercules-ci-api/src/Hercules/API/Agents/AgentSession.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/AgentSession.hs
@@ -3,7 +3,8 @@ module Hercules.API.Agents.AgentSession where
 
 import           Hercules.API.Prelude
 
-import           Hercules.API.Agents.ClusterJoinToken ( ClusterJoinToken )
+import           Hercules.API.Agents.ClusterJoinToken
+                                                ( ClusterJoinToken )
 
 data AgentSession = AgentSession
   { hostname :: Text

--- a/hercules-ci-api/src/Hercules/API/Agents/AgentSessionCreated.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/AgentSessionCreated.hs
@@ -2,8 +2,10 @@
 module Hercules.API.Agents.AgentSessionCreated where
 
 import           Hercules.API.Prelude
-import           Hercules.API.Agents.AgentSession      ( AgentSession )
-import           Hercules.API.Agents.ClusterJoinToken ( ClusterJoinToken )
+import           Hercules.API.Agents.AgentSession
+                                                ( AgentSession )
+import           Hercules.API.Agents.ClusterJoinToken
+                                                ( ClusterJoinToken )
 
 data AgentSessionCreated = AgentSessionCreated
   { hostname :: Text

--- a/hercules-ci-api/src/Hercules/API/Agents/FullClusterJoinToken.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/FullClusterJoinToken.hs
@@ -3,7 +3,8 @@ module Hercules.API.Agents.FullClusterJoinToken where
 
 import           Hercules.API.Prelude
 
-import           Hercules.API.Agents.ClusterJoinToken ( ClusterJoinToken )
+import           Hercules.API.Agents.ClusterJoinToken
+                                                ( ClusterJoinToken )
 
 data FullClusterJoinToken = FullClusterJoinToken
   { metadata :: ClusterJoinToken

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,9 +2,19 @@
 , nixpkgsSource ? "nixos-18.09"
 , nixpkgs ? sources."${nixpkgsSource}"
 }:
-with
-  { dev-overlay = self: pkgs:
-      { inherit (import sources.niv {}) niv;
-      };
+let
+  dev-overlay = self: pkgs: {
+    devTools = {
+      inherit (pkgs)
+        shellcheck
+        ;
+      inherit (import sources.niv {})
+        niv
+        ;
+      inherit (pkgs.haskellPackages)
+        brittany
+        ;
+    };
   };
+in
 import nixpkgs { overlays = [ (import ./overlay.nix) dev-overlay ] ; config = {}; }

--- a/scripts/format-and-lint
+++ b/scripts/format-and-lint
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LANG=en_US.utf-8
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+BRITTANY=$(nix-build --no-out-link ./nix -A devTools.brittany)/bin/brittany
+SHELLCHECK=$(nix-build --no-out-link ./nix -A devTools.shellcheck)/bin/shellcheck
+
+echo "Processing Haskell files with brittany"
+
+# Filtering out QuasiQuotes due to 
+# https://github.com/lspitzner/brittany/issues/90
+git ls-files | grep 'hs$' | xargs grep -L CPP | xargs grep -L QuasiQuotes | xargs "$BRITTANY" --write-mode inplace
+
+echo "Processing scripts with shellcheck"
+# shellcheck disable=SC2046
+$SHELLCHECK $(find scripts -executable -type f)
+
+git diff -w --text --exit-code

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
 with { pkgs = import ./nix {}; };
 pkgs.mkShell
-  { buildInputs = [ pkgs.niv ];
+  { buildInputs = [ pkgs.devTools.niv ];
   }

--- a/tests/agent-test/hercules-ci-agent-test.cabal
+++ b/tests/agent-test/hercules-ci-agent-test.cabal
@@ -23,6 +23,7 @@ source-repository head
 executable hercules-ci-agent-test
   main-is: Main.hs
   other-modules:
+      AgentTask
       DummyApi
       EvaluationSpec
       MockTasksApi

--- a/tests/agent-test/src/AgentTask.hs
+++ b/tests/agent-test/src/AgentTask.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveAnyClass #-}
-module Hercules.API.AgentTask where
+module AgentTask where
 
 import           Hercules.API.Prelude
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
 
 data AgentTask = Evaluate EvaluateTask.EvaluateTask
                | Build Text

--- a/tests/agent-test/src/AgentTask.hs
+++ b/tests/agent-test/src/AgentTask.hs
@@ -2,7 +2,8 @@
 module AgentTask where
 
 import           Hercules.API.Prelude
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
 
 data AgentTask = Evaluate EvaluateTask.EvaluateTask
                | Build Text

--- a/tests/agent-test/src/DummyApi.hs
+++ b/tests/agent-test/src/DummyApi.hs
@@ -8,7 +8,8 @@ module DummyApi
 where
 
 import           Servant.Server.Generic
-import           Hercules.API
+import           Hercules.API.Agent.Evaluate
+import           Hercules.API.Agent.Tasks
 import           Hercules.API.Agents
 
 -- Provide uninitialised API records without warnings

--- a/tests/agent-test/src/EvaluationSpec.hs
+++ b/tests/agent-test/src/EvaluationSpec.hs
@@ -8,9 +8,11 @@ import           Prelude                        ( userError
 import qualified Data.Map                      as M
 import qualified Data.UUID.V4                  as UUID
 import           Hercules.API.Id                ( Id(Id) )
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.Agent.Evaluate.EvaluateEvent    as EvaluateEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent
+                                               as EvaluateEvent
 import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent
                                                as AttributeEvent
 import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent
@@ -82,8 +84,7 @@ spec = describe "Evaluation" $ do
           [EvaluateEvent.Message msg] -> msg `shouldBe` Message.Message
             { index = 0
             , typ = Message.Error
-            , message =
-              "Please provide a Nix expression to build. Could not find any of \"nix/ci.nix\", \"ci.nix\" or \"default.nix\" in your source"
+            , message = "Please provide a Nix expression to build. Could not find any of \"nix/ci.nix\", \"ci.nix\" or \"default.nix\" in your source"
             }
 
           _ -> failWith $ "Events should be a single message, not: " <> show r

--- a/tests/agent-test/src/EvaluationSpec.hs
+++ b/tests/agent-test/src/EvaluationSpec.hs
@@ -8,12 +8,12 @@ import           Prelude                        ( userError
 import qualified Data.Map                      as M
 import qualified Data.UUID.V4                  as UUID
 import           Hercules.API.Id                ( Id(Id) )
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.EvaluateEvent    as EvaluateEvent
-import qualified Hercules.API.EvaluateEvent.AttributeEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent    as EvaluateEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEvent
                                                as AttributeEvent
-import qualified Hercules.API.EvaluateEvent.AttributeErrorEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeErrorEvent
                                                as AttributeErrorEvent
 import qualified Hercules.API.Message          as Message
 import           MockTasksApi

--- a/tests/agent-test/src/MockTasksApi.hs
+++ b/tests/agent-test/src/MockTasksApi.hs
@@ -43,15 +43,18 @@ import           Hercules.API.Agents            ( AgentsAPI )
 import qualified Hercules.API.Agents           as API.Agents
 import qualified Hercules.API.Agents.CreateAgentSession
                                                as CreateAgentSession
-import           Hercules.API.Agents.AgentSession      ( AgentSession )
+import           Hercules.API.Agents.AgentSession
+                                                ( AgentSession )
 import qualified AgentTask
 import           Hercules.API.Task              ( Task )
 import qualified Hercules.API.Task             as Task
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
-import qualified Hercules.API.Agent.Evaluate.EvaluateEvent    as EvaluateEvent
-import  Hercules.API.Agent.Tasks    (TasksAPI(..))
-import  Hercules.API.Agent.Evaluate    (EvalAPI(..))
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask
+                                               as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent
+                                               as EvaluateEvent
+import           Hercules.API.Agent.Tasks       ( TasksAPI(..) )
+import           Hercules.API.Agent.Evaluate    ( EvalAPI(..) )
 import           Control.Concurrent             ( newEmptyMVar )
 import           Control.Concurrent.STM
 import qualified Streaming                     as Streaming
@@ -66,7 +69,7 @@ import qualified Data.Text                     as T
 import qualified Data.Conduit.Tar              as Tar
 import           Data.Conduit.Zlib              ( gzip )
 import qualified DummyApi
-import           Orphans                        ()
+import           Orphans                        ( )
 
 data ServerState = ServerState
   { queue :: MVar (Task Task.Any)
@@ -312,8 +315,9 @@ instance ToJWT Session
 type Auth' = Auth '[JWT] Session
 
 agentsEndpoints :: ServerState -> AgentsAPI Auth' AsServer
-agentsEndpoints server =
-  DummyApi.dummyAgentsEndpoints { API.Agents.agentSessionCreate = handleAgentCreate }
+agentsEndpoints server = DummyApi.dummyAgentsEndpoints
+  { API.Agents.agentSessionCreate = handleAgentCreate
+  }
 
 handleAgentCreate :: CreateAgentSession.CreateAgentSession
                   -> AuthResult Session

--- a/tests/agent-test/src/MockTasksApi.hs
+++ b/tests/agent-test/src/MockTasksApi.hs
@@ -44,12 +44,14 @@ import qualified Hercules.API.Agents           as API.Agents
 import qualified Hercules.API.Agents.CreateAgentSession
                                                as CreateAgentSession
 import           Hercules.API.Agents.AgentSession      ( AgentSession )
-import qualified Hercules.API.AgentTask        as AgentTask
+import qualified AgentTask
 import           Hercules.API.Task              ( Task )
 import qualified Hercules.API.Task             as Task
 import qualified Hercules.API.TaskStatus       as TaskStatus
-import qualified Hercules.API.EvaluateTask     as EvaluateTask
-import qualified Hercules.API.EvaluateEvent    as EvaluateEvent
+import qualified Hercules.API.Agent.Evaluate.EvaluateTask     as EvaluateTask
+import qualified Hercules.API.Agent.Evaluate.EvaluateEvent    as EvaluateEvent
+import  Hercules.API.Agent.Tasks    (TasksAPI(..))
+import  Hercules.API.Agent.Evaluate    (EvalAPI(..))
 import           Control.Concurrent             ( newEmptyMVar )
 import           Control.Concurrent.STM
 import qualified Streaming                     as Streaming


### PR DESCRIPTION
Getting this out of the way before I make things worse.
Also
 - formats code
 - adds format-and-lint script

No CI for format-and-lint, but that can wait.