### PR TITLE
Add GitCommitSource to a job

### DIFF
--- a/hercules-ci-api/src/Hercules/API/Projects/Job.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/Job.hs
@@ -5,6 +5,7 @@ import           Hercules.API.Prelude
 
 import           Hercules.API.Repos.Repo        ( Repo )
 import           Hercules.API.Projects.Project  ( Project )
+import           Hercules.API.Accounts.Account  ( Account )
 import           Hercules.API.Evaluation.Evaluation
                                                 ( Evaluation )
 
@@ -13,7 +14,6 @@ data Job = Job
   , projectId :: Id Project
   , index :: Int64
   , repoId :: Id Repo
-  , revision :: Text
   , startTime :: UTCTime
   , endTime :: Maybe UTCTime
   , jobPhase :: JobPhase
@@ -21,8 +21,20 @@ data Job = Job
   , evaluationStatus :: JobStatus
   , derivationStatus :: JobStatus
   , evaluationId :: Id Evaluation
+  , source :: GitCommitSource
   }
   deriving (Generic, Show, Eq, ToJSON, FromJSON, ToSchema)
+
+
+data GitCommitSource = GitCommitSource
+  { revision :: Text
+  , ref :: Text
+  , message :: Text
+  , gitCommiterName :: Text
+  , committerSlug :: Maybe (Name Account)
+  }
+  deriving (Generic, Show, Eq, ToJSON, FromJSON, ToSchema)
+
 
 data JobPhase
   = Queued


### PR DESCRIPTION
This breaks backward compatibility, but only the frontend is using that HTTP API for now.