### PR TITLE
nixops-hercules-ci-agent.nix: prefix "agent-token.key" with something hercules-specific

### DIFF
--- a/for-upstream-only/nixos/profiles/nixops-hercules-ci-agent.nix
+++ b/for-upstream-only/nixos/profiles/nixops-hercules-ci-agent.nix
@@ -10,9 +10,10 @@
 
   users.extraUsers.hercules-ci-agent.extraGroups = [ "keys" ];
 
-  deployment.keys."agent-token.key" = {
+  deployment.keys."hercules-ci-agent-token" = {
     user = config.services.hercules-ci-agent.user;
     destDir = "/var/lib/keys/hercules-ci-agent";
+    path = "/var/lib/keys/hercules-ci-agent/agent-token.key";
   };
 
 }


### PR DESCRIPTION
When looking at a larger nixops deployment, having a key named
"agent-token.key" becomes quite meaningless.
Prefix it with "hercules-ci-agent", so it becomes easy recognizable.

Closes #54.