### PR TITLE
agent: Fix for potential partial success in task success

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ for your Hercules CI account.
 
 ## Hacking
 
-   $ nix-shell -p stack
-   $ stack --nix test --file-watch
+    $ nix-shell -p stack
+    $ stack --nix test --file-watch

--- a/default.nix
+++ b/default.nix
@@ -14,4 +14,12 @@ let
   pkgs = import nixpkgs { overlays = [ (import ./nix/overlay.nix) dev-and-test-overlay ] ; config = {}; };
 in pkgs.recurseIntoAttrs {
   inherit (pkgs) hercules-ci-agent hercules-ci-agent-packages;
+  devTools = {
+    inherit (pkgs)
+      shellcheck
+      ;
+    inherit (import sources.niv {})
+      niv
+      ;
+  };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,15 @@
 { sources ? import ./nix/sources.nix
 , nixpkgsSource ? "nixos-19.03"
 , nixpkgs ? sources."${nixpkgsSource}"
-
   # Sharing the test suite
 , allTargets ? import ./nix/ci.nix
 , testSuiteTarget ? "nixos-19_03"
 , testSuitePkgs ? allTargets."${testSuiteTarget}"
 }:
+
 let
   dev-and-test-overlay = self: pkgs: {
-
     inherit testSuitePkgs;
-
-    devTools = {
-      inherit (pkgs)
-        shellcheck
-        ;
-      inherit (import sources.niv {})
-        niv
-        ;
-      inherit (pkgs.haskellPackages)
-        brittany
-        ;
-    };
   };
   pkgs = import nixpkgs { overlays = [ (import ./nix/overlay.nix) dev-and-test-overlay ] ; config = {}; };
 in pkgs.recurseIntoAttrs {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,13 +8,4 @@ in {
 
   # overrides
   hercules-ci-agent = pkgs.haskell.lib.justStaticExecutables self.hercules-ci-agent-packages.hercules-ci-agent;
-
-  devTools = {
-    inherit (pkgs)
-      shellcheck
-      ;
-    inherit (import sources.niv {})
-      niv
-      ;
-  };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,8 +1,20 @@
 self: pkgs:
-{
+
+let
+  sources = import ./sources.nix;
+in {
   # packages defined in this repo
   hercules-ci-agent-packages = pkgs.callPackages ./packages.nix {};
 
   # overrides
   hercules-ci-agent = pkgs.haskell.lib.justStaticExecutables self.hercules-ci-agent-packages.hercules-ci-agent;
+
+  devTools = {
+    inherit (pkgs)
+      shellcheck
+      ;
+    inherit (import sources.niv {})
+      niv
+      ;
+  };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,10 @@
-with { pkgs = import ./nix {}; };
-pkgs.mkShell
-  { buildInputs = [ pkgs.devTools.niv ];
-  }
+{ sources ? import ./nix/sources.nix
+, nixpkgsSource ? "nixos-19.03"
+, nixpkgs ? sources."${nixpkgsSource}"
+}:
+
+let
+  pkgs = import nixpkgs { overlays = [ (import ./nix/overlay.nix) ] ; config = {}; };
+in pkgs.mkShell {
+  buildInputs = [ pkgs.devTools.niv pkgs.devTools.shellcheck ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@
 
 let
   pkgs = import nixpkgs { overlays = [ (import ./nix/overlay.nix) ] ; config = {}; };
+  agentpkgs = import ./default.nix {};
 in pkgs.mkShell {
-  buildInputs = [ pkgs.devTools.niv pkgs.devTools.shellcheck ];
+  buildInputs = [ agentpkgs.devTools.niv agentpkgs.devTools.shellcheck ];
 }


### PR DESCRIPTION
Suppose the success event is recorded by the service, but the
response doesn't make it, this ensures that success xor failure
is reported.
Also it adds retries.