### PR TITLE
cache.nixos.org should contain a trailing slash

### DIFF
--- a/for-upstream-only/nixos/profiles/cache-keys-json.nix
+++ b/for-upstream-only/nixos/profiles/cache-keys-json.nix
@@ -84,7 +84,7 @@ in
       }
     ];
 
-    nix.trustedBinaryCaches = ["https://cache.nixos.org"] ++ mapAttrsToList (name: keys: "https://${name}.cachix.org") cachixCaches;
+    nix.trustedBinaryCaches = ["https://cache.nixos.org/"] ++ mapAttrsToList (name: keys: "https://${name}.cachix.org") cachixCaches;
     nix.binaryCachePublicKeys = concatLists (mapAttrsToList (name: keys: keys.publicKeys) cachixCaches);
 
     nix.extraOptions = ''

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix.hs
@@ -63,7 +63,7 @@ getSubstituters = do
   cks <- asks (Agent.Cachix.cacheKeys . Agent.Env.cachixEnv)
 
   -- TODO: merge with system config instead
-  pure $ ["https://cache.nixos.org"] ++ map (\c -> "https://" <> c <> ".cachix.org") (M.keys cks)
+  pure $ ["https://cache.nixos.org/"] ++ map (\c -> "https://" <> c <> ".cachix.org") (M.keys cks)
 
 withCaches :: App a -> App a
 withCaches m = do


### PR DESCRIPTION
Unfortunately urls are not normalized and that's upstream default.

- [x] test