### PR TITLE
agent: Move session.key into base/secrets, independent of *static*SecretsDir

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
@@ -18,7 +18,7 @@ import           System.FilePath                ( (</>) )
 import           Hercules.Agent.Log
 
 getDir :: App FilePath
-getDir = asks ((</> "secrets") . baseDirectory . config)
+getDir = asks ((</> "secretState") . baseDirectory . config)
 
 writeAgentSessionKey :: Text -> App ()
 writeAgentSessionKey tok = do

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Token.hs
@@ -18,7 +18,7 @@ import           System.FilePath                ( (</>) )
 import           Hercules.Agent.Log
 
 getDir :: App FilePath
-getDir = asks (baseDirectory . config)
+getDir = asks ((</> "secrets") . baseDirectory . config)
 
 writeAgentSessionKey :: Text -> App ()
 writeAgentSessionKey tok = do


### PR DESCRIPTION
We'll have a dynamicSecretsDirectory later.

Having a `secrets` directory on the filesystem suggests that all secrets are there. This satisfies that expectation.

 - [x] tested locally