### PR TITLE
api: Unquote the swagger output

### DIFF
--- a/hercules-ci-api/hercules-gen-swagger/Main.hs
+++ b/hercules-ci-api/hercules-gen-swagger/Main.hs
@@ -6,7 +6,7 @@ where
 import           Prelude
 import           Data.Aeson                     ( encode )
 import           Hercules.API                   ( swagger )
-
+import           Data.String.Conv               ( toS )
 
 main :: IO ()
-main = print $ encode swagger
+main = putStrLn $ toS $ encode swagger

--- a/hercules-ci-api/swagger.nix
+++ b/hercules-ci-api/swagger.nix
@@ -1,6 +1,7 @@
 { hercules-ci-api, runCommand, ... }:
 
 runCommand "hercules-swagger" {
+  LANG = "C.UTF-8";
 } ''
   mkdir $out
   ${hercules-ci-api}/bin/hercules-gen-swagger >$out/swagger.json


### PR DESCRIPTION
It was printed as a Haskell string
which is a funny thing
Parsers started throwing
because gen-elm was showing

— author unknown