### PR TITLE
Log when evaluator starts to push to cachix

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Evaluate.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Evaluate.hs
@@ -242,6 +242,7 @@ performEvaluation task' = do
                 caches <- Agent.Cachix.activePushCaches
                 paths <- liftIO $ readIORef allAttrPaths
                 forM_ caches $ \cache -> do
+                  withNamedContext "cache" cache $ logLocM DebugS "Pushing drvs to cachix"
                   Agent.Cachix.push cache (toList paths)
                   liftIO $ emit $ EvaluateEvent.PushedAll $ PushedAll.PushedAll { cache = cache }
 


### PR DESCRIPTION
This will give us a bit better understanding where time is spent during eval.