### PR TITLE
Disable parallel gc to improve runtime performance

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent.cabal
+++ b/hercules-ci-agent/hercules-ci-agent.cabal
@@ -91,7 +91,7 @@ executable hercules-ci-agent
   hs-source-dirs:
       hercules-ci-agent
   default-extensions: DeriveGeneric DeriveTraversable DisambiguateRecordFields FlexibleContexts InstanceSigs LambdaCase MultiParamTypeClasses NoImplicitPrelude OverloadedStrings RankNTypes TupleSections TypeApplications TypeOperators
-  ghc-options: -Wall -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-name-shadowing -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-maxN8
+  ghc-options: -Wall -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-name-shadowing -fwarn-incomplete-patterns -threaded -rtsopts "-with-rtsopts=-maxN8 -qg"
   build-depends:
       aeson
     , async


### PR DESCRIPTION
Currently idle agent takes about 20-40% of CPU (with downscaled frequency), ~3% per each thread.

Disable parallel GC to save up CPU at the cost of bigger pauses.