### PR TITLE
Fix nixos auto restart

### DIFF
--- a/for-upstream/default.nixos.nix
+++ b/for-upstream/default.nixos.nix
@@ -44,10 +44,7 @@ in
       wantedBy = [ "hercules-ci-agent.service" ];
       pathConfig = {
         Unit = "hercules-ci-agent-restarter.service";
-        PathChanged = [
-          cfg.finalConfig.clusterJoinTokenPath
-          cfg.finalConfig.binaryCachesPath
-        ];
+        PathChanged = [ cfg.finalConfig.clusterJoinTokenPath ] ++ lib.optional (cfg.finalConfig ? binaryCachesPath) cfg.finalConfig.binaryCachesPath;
       };
     };
 

--- a/for-upstream/default.nixos.nix
+++ b/for-upstream/default.nixos.nix
@@ -41,7 +41,7 @@ in
     };
 
     systemd.paths.hercules-ci-agent = {
-      wantedBy = [ "herucles-ci-agent.service" ];
+      wantedBy = [ "hercules-ci-agent.service" ];
       pathConfig = {
         PathChanged = [ cfg.secretsDirectory ];
       };

--- a/for-upstream/default.nixos.nix
+++ b/for-upstream/default.nixos.nix
@@ -40,11 +40,22 @@ in
       };
     };
 
-    systemd.paths.hercules-ci-agent = {
+    systemd.paths.hercules-ci-agent-restart-files = {
       wantedBy = [ "hercules-ci-agent.service" ];
       pathConfig = {
-        PathChanged = [ cfg.secretsDirectory ];
+        Unit = "hercules-ci-agent-restarter.service";
+        PathChanged = [
+          cfg.finalConfig.clusterJoinTokenPath
+          cfg.finalConfig.binaryCachesPath
+        ];
       };
+    };
+
+    systemd.services.hercules-ci-agent-restarter = {
+      serviceConfig.Type = "oneshot";
+      script = ''
+        systemctl restart hercules-ci-agent.service
+      '';
     };
 
     users = mkIf (cfg.user == defaultUser) {


### PR DESCRIPTION
Path units do not seem to be capable of restarting services, so
this introduces a oneshot service that is *started* and restarts
the actual service.

Closes #137 