### PR TITLE
agent: Require binary-caches.json *file*

### DIFF
--- a/hercules-ci-agent/CHANGELOG.md
+++ b/hercules-ci-agent/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `binary-caches.json` file is now required. The empty object `{}` makes a
+  valid file, but we highly recommend to configure a cache.
+
+- The `services.hercules-ci-agent.binaryCachesFile` option has been removed.
+  `binary-caches.json` can now be deployed like any other secrets file.
+
+  **NixOps users**: rename to `deployment.keys."binary-caches.json".file`
+
+  **Others**: remove your `binaryCachesFile` value. Make sure `binary-caches.json` is deployed.
+
+
 ## [0.4.0] - 2019-08-30
 
 ### Added

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/BinaryCaches.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/BinaryCaches.hs
@@ -7,6 +7,7 @@ module Hercules.Agent.BinaryCaches
     )
 where
 
+import Control.Exception.Lifted (catchJust)
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as M
@@ -15,18 +16,14 @@ import Hercules.Agent.Config
 import Hercules.Agent.Log
 import Hercules.Error
 import Hercules.Formats.CachixCache
-import Protolude
-import System.Directory (doesFileExist)
-import System.FilePath ((</>))
+import Protolude hiding (catchJust)
+import System.IO.Error (isDoesNotExistError)
 
 data BinaryCaches
   = BinaryCaches
       { cachixCaches :: Map Text CachixCache,
         unknownKinds :: Map Text UnknownKind
         }
-
-noCaches :: BinaryCaches
-noCaches = BinaryCaches mempty mempty
 
 data UnknownKind = UnknownKind {kind :: Text}
   deriving (Generic, FromJSON)
@@ -44,7 +41,21 @@ instance FromJSON BinaryCaches where
 parseFile :: Config 'Final -> KatipContextT IO BinaryCaches
 parseFile cfg = do
   let fname = binaryCachesPath cfg
-  bytes <- liftIO $ BL.readFile $ toS fname
+  bytes <-
+    catchJust
+      (mfilter isDoesNotExistError . Just)
+      (liftIO (BL.readFile (toS fname)))
+      ( \_e ->
+          liftIO $ throwIO $ FatalError
+            $ "The binary-caches.json file does not exist.\
+              \\nAccording to the configuration, it should be in\
+              \\n  "
+            <> toS fname
+            <> "\
+              \\n\
+              \\nFor more information about binary-caches.json, see\n\
+              \\nhttps://docs.hercules-ci.com/hercules-ci/reference/binary-caches-json/"
+        )
   bcs <- escalateAs (FatalError . toS) $ eitherDecode bytes
   validate (toS fname) bcs
   pure bcs
@@ -56,7 +67,9 @@ validate fname bcs = do
         WarningS
         "You did not configure any caches. This is ok for evaluation purposes,\
         \ but a cache is required for multi-agent operation and\
-        \ to work well across garbage collection."
+        \ to work well across garbage collection.\
+        \ For more information about binary-caches.json, see\
+        \ https://docs.hercules-ci.com/hercules-ci/reference/binary-caches-json/"
   forM_ (M.toList (unknownKinds bcs)) $ \(k, v) ->
     logLocM WarningS
       $ "In file "

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
@@ -45,7 +45,7 @@ data Config purpose
         -- ^ Read-only
         workDirectory :: Item purpose 'Required FilePath,
         clusterJoinTokenPath :: Item purpose 'Required FilePath,
-        binaryCachesPath :: Item purpose 'Optional FilePath
+        binaryCachesPath :: Item purpose 'Required FilePath
         }
   deriving (Generic)
 
@@ -102,6 +102,10 @@ finalizeConfig loc input = do
         fromMaybe
           (staticSecretsDir </> "cluster-join-token.key")
           (clusterJoinTokenPath input)
+      binaryCachesP =
+        fromMaybe
+          (staticSecretsDir </> "binary-caches.json")
+          (binaryCachesPath input)
       workDir = fromMaybe (baseDir </> "work") (workDirectory input)
   dabu <- determineDefaultApiBaseUrl
   let rawConcurrentTasks = fromMaybe defaultConcurrentTasks $ concurrentTasks input
@@ -111,7 +115,7 @@ finalizeConfig loc input = do
       x -> pure x
   pure Config
     { herculesApiBaseURL = fromMaybe dabu $ herculesApiBaseURL input,
-      binaryCachesPath = binaryCachesPath input,
+      binaryCachesPath = binaryCachesP,
       clusterJoinTokenPath = clusterJoinTokenP,
       concurrentTasks = validConcurrentTasks,
       baseDirectory = baseDir,

--- a/tests/agent-test.nix
+++ b/tests/agent-test.nix
@@ -32,6 +32,7 @@ in
         nix.binaryCaches = lib.mkForce [];
         services.hercules-ci-agent.enable = true;
         services.hercules-ci-agent.extraOptions.apiBaseUrl = "http://api";
+        services.hercules-ci-agent.extraOptions.binaryCachesPath = (pkgs.writeText "binary-caches.json" (builtins.toJSON {})).outPath;
         services.hercules-ci-agent.extraOptions.clusterJoinTokenPath = (pkgs.writeText "pretend-agent-token" "").outPath;
         services.hercules-ci-agent.concurrentTasks = 4; # Decrease on itest memory problems
 


### PR DESCRIPTION
 - Provide the right error message for virtually everyone
 - Less cognitive overhead in the module

Merging into netrc-use-trusted.