### PR TITLE
Increase eval push workers to 16

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
@@ -118,7 +118,7 @@ push buildTask outs = do
   let paths = OutputInfo.path <$> toList outs
   caches <- Agent.Cachix.activePushCaches
   forM_ caches $ \cache -> do
-    Agent.Cachix.push cache paths
+    Agent.Cachix.push cache paths 4
     emitEvents buildTask [BuildEvent.Pushed $ Pushed.Pushed {cache = cache}]
 
 reportSuccess :: BuildTask -> App ()

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix.hs
@@ -23,8 +23,8 @@ import Protolude
 import qualified Servant.Client as Servant
 import System.IO (hClose)
 
-push :: Text -> [Text] -> App ()
-push cache paths = withNamedContext "cache" cache $ do
+push :: Text -> [Text] -> Int -> App ()
+push cache paths workers = withNamedContext "cache" cache $ do
   Agent.Cachix.Env {pushCaches = pushCaches, nixStore = nixStore} <-
     asks $ Agent.Cachix.getEnv
   httpManager <- asks $ manager
@@ -38,7 +38,7 @@ push cache paths = withNamedContext "cache" cache $ do
   void
     $ Cachix.Push.pushClosure
         ( \f l ->
-            liftIO $ Cachix.Push.mapConcurrentlyBounded 4 (fmap (unliftIO ul) f) l
+            liftIO $ Cachix.Push.mapConcurrentlyBounded workers (fmap (unliftIO ul) f) l
           )
         clientEnv
         nixStore


### PR DESCRIPTION
Fixes #170

Derivation size is really small, so we can have a higher default of concurrent workers for evaluation.