### PR TITLE
Worker: Use M.insert to avoid Monoid order mistake

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
@@ -147,7 +147,7 @@ runCommands herculesState = do
           )
     Command.BuildResult (BuildResult.BuildResult path attempt result) -> do
       hPutStrLn stderr $ ("BuildResult: " <> show path <> " " <> show result :: Text)
-      liftIO $ atomically $ modifyTVar (drvsCompleted herculesState) (<> M.singleton path (attempt, result))
+      liftIO $ atomically $ modifyTVar (drvsCompleted herculesState) (M.insert path (attempt, result))
 
 -- TODO: test
 autoArgArgs :: Map Text Eval.Arg -> [ByteString]


### PR DESCRIPTION
It didn't update right when a drv has to be rebuilt in quick succession, due to quick GC or fluke.