### PR TITLE
Add aarch64-linux builds

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -18,6 +18,7 @@ let
 
 
       dimension "System" {
+        "aarch64-linux" = { enable = true; };
         "x86_64-linux" = { enable = true; };
         "x86_64-darwin" = { enable = true; };
       } (

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -133,7 +133,8 @@ in
 recurseIntoAttrs {
   inherit (internal.haskellPackages) hercules-ci-agent;
   inherit (internal) hercules-ci-api-swagger;
-  tests = if pkgs.stdenv.isLinux then internal.tests else null;
+  # isx86_64: Don't run the VM tests on aarch64 to save time
+  tests = if pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 then internal.tests else null;
   pre-commit-check =
     (import sources."pre-commit-hooks.nix").run {
       src = ../.;


### PR DESCRIPTION
The integration tests worked on a heavy aarch64 machine, but are not worth running on every push now.