### PR TITLE
agent: requireMaterializedDerivations -> nixUserIsTrusted

### DIFF
--- a/for-upstream/default.nix-darwin.nix
+++ b/for-upstream/default.nix-darwin.nix
@@ -44,7 +44,10 @@ in
       chown ${toString user.uid}:${toString user.gid} '${cfg.logFile}'
     '';
 
+    # Trusted user allows simplified configuration and better performance
+    # when operating in a cluster.
     nix.trustedUsers = [ "hercules-ci-agent" ];
+    services.hercules-ci-agent.extraOptions.nixUserIsTrusted = true;
 
     users.knownGroups = [ "hercules-ci-agent" ];
     users.knownUsers = [ "hercules-ci-agent" ];

--- a/for-upstream/default.nixos.nix
+++ b/for-upstream/default.nixos.nix
@@ -69,7 +69,10 @@ in
       '';
     };
 
+    # Trusted user allows simplified configuration and better performance
+    # when operating in a cluster.
     nix.trustedUsers = [ cfg.user ];
+    services.hercules-ci-agent.extraOptions.nixUserIsTrusted = true;
 
     users = mkIf (cfg.user == defaultUser) {
       users.hercules-ci-agent =

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
@@ -59,7 +59,7 @@ performBuild buildTask = do
           panic e
         _ -> pass
   baseURL <- asks (ServiceInfo.bulkSocketBaseURL . Env.serviceInfo)
-  materialize <- asks (Config.requireMaterializedDerivations . Env.config)
+  materialize <- asks (not . Config.nixUserIsTrusted . Env.config)
   liftIO $ writeChan commandChan $ Just $ Command.Build $ Command.Build.Build
     { drvPath = BuildTask.derivationPath buildTask,
       inputDerivationOutputPaths = toS <$> BuildTask.inputDerivationOutputPaths buildTask,

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
@@ -39,7 +39,7 @@ type FinalConfig = Config 'Final
 data Config purpose
   = Config
       { herculesApiBaseURL :: Item purpose 'Required Text,
-        requireMaterializedDerivations :: Item purpose 'Required Bool,
+        nixUserIsTrusted :: Item purpose 'Required Bool,
         concurrentTasks :: Item purpose 'Required Integer,
         baseDirectory :: Item purpose 'Required FilePath,
         -- | Read-only
@@ -57,8 +57,8 @@ tomlCodec =
   Config
     <$> dioptional (Toml.text "apiBaseUrl")
     .= herculesApiBaseURL
-    <*> dioptional (Toml.bool "requireMaterializedDerivations")
-    .= requireMaterializedDerivations
+    <*> dioptional (Toml.bool "nixUserIsTrusted")
+    .= nixUserIsTrusted
     <*> dioptional (Toml.integer "concurrentTasks")
     .= concurrentTasks
     <*> dioptional (Toml.string keyBaseDirectory)
@@ -119,7 +119,7 @@ finalizeConfig loc input = do
   let apiBaseUrl = fromMaybe dabu $ herculesApiBaseURL input
   pure Config
     { herculesApiBaseURL = apiBaseUrl,
-      requireMaterializedDerivations = fromMaybe False $ requireMaterializedDerivations input,
+      nixUserIsTrusted = fromMaybe False $ nixUserIsTrusted input,
       binaryCachesPath = binaryCachesP,
       clusterJoinTokenPath = clusterJoinTokenP,
       concurrentTasks = validConcurrentTasks,

--- a/tests/agent-test.nix
+++ b/tests/agent-test.nix
@@ -33,7 +33,7 @@ in
         services.hercules-ci-agent.enable = true;
         services.hercules-ci-agent.patchNix = true;
         services.hercules-ci-agent.extraOptions.apiBaseUrl = "http://api";
-        services.hercules-ci-agent.extraOptions.requireMaterializedDerivations = true;
+        services.hercules-ci-agent.extraOptions.nixUserIsTrusted = lib.mkForce false;
         services.hercules-ci-agent.extraOptions.binaryCachesPath = (pkgs.writeText "binary-caches.json" (builtins.toJSON {})).outPath;
         services.hercules-ci-agent.extraOptions.clusterJoinTokenPath = (pkgs.writeText "pretend-agent-token" "").outPath;
         services.hercules-ci-agent.concurrentTasks = 4; # Decrease on itest memory problems


### PR DESCRIPTION
Generalizes the config item and sets it in the NixOS and nix-darwin modules.

Refs https://github.com/hercules-ci/docs.hercules-ci.com/issues/102