### PR TITLE
Recover from unexpected missing cache paths

### DIFF
--- a/hercules-ci-agent/src-cnix/CNix.hs
+++ b/hercules-ci-agent/src-cnix/CNix.hs
@@ -106,6 +106,13 @@ setOption opt value = do
     settings.set($bs-cstr:optionStr, $bs-cstr:valueStr);
   }|]
 
+logInfo :: Text -> IO ()
+logInfo t = do
+  let bstr = encodeUtf8 t
+  [C.throwBlock| void {
+    printInfo($bs-cstr:bstr);
+  }|]
+
 mkBindings :: Ptr Bindings' -> IO Bindings
 mkBindings p = pure $ Bindings p
 


### PR DESCRIPTION
This affected agent 0.7 - 0.7.3 users with trusted user optimizations turned on; the default when using the NixOS or nix-darwin modules.