### PR TITLE
Add entries from ambient Nix netrc-file

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
@@ -22,7 +22,7 @@ import qualified Unsafe.Coerce
 
 withCaches :: App a -> App a
 withCaches m = do
-  netrcLns <- Cachix.getNetrcLines
+  netrcLns <- (<>) <$> Cachix.getNetrcLines <*> Nix.getNetrcLines
   csubsts <- Cachix.getSubstituters
   cpubkeys <- Cachix.getTrustedPublicKeys
   nixCaches <- asks (Config.nixCaches . Env.binaryCaches)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/EnvironmentInfo.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/EnvironmentInfo.hs
@@ -52,7 +52,8 @@ data NixInfo
         nixSystemFeatures :: [Text],
         nixSubstituters :: [Text],
         nixTrustedPublicKeys :: [Text],
-        nixNarinfoCacheNegativeTTL :: Maybe Integer
+        nixNarinfoCacheNegativeTTL :: Maybe Integer,
+        nixNetrcFile :: Maybe Text
       }
 
 getNixInfo :: IO NixInfo
@@ -103,7 +104,12 @@ getNixInfo = do
           ^? key "narinfo-cache-negative-ttl"
           . key "value"
           . _Number
-          . to floor
+          . to floor,
+      nixNetrcFile =
+        cfg
+          ^? key "netrc-file"
+          . key "value"
+          . _String
     }
 
 cleanUrl :: Text -> Text

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Nix.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Nix.hs
@@ -52,7 +52,7 @@ getNetrcLines :: App [Text]
 getNetrcLines = liftIO $ do
   info <- getNixInfo
   let fm = toS <$> nixNetrcFile info
-  fmap (foldMap identity) <$> runMaybeT $ do
+  fmap fold <$> runMaybeT $ do
     f <- MaybeT $ pure fm
     exs <- lift $ doesFileExist f
     guard exs


### PR DESCRIPTION
Makes `netrc-file` in `~hercules-ci-agent/.config/nix/nix.conf` work.