### PR TITLE
cachix: 0.3.8 -> 0.5.1

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Init.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Init.hs
@@ -61,8 +61,10 @@ toPushCaches = sequenceA . M.mapMaybeWithKey toPushCaches'
             sk <- head $ CachixCache.signingKeys keys
             Just $ escalateAs FatalError $ do
               k' <- Cachix.Secrets.parseSigningKeyLenient sk
-              pure $ Cachix.Push.PushCache
+              pure Cachix.Push.PushCache
                 { pushCacheName = name,
-                  pushCacheSigningKey = k',
-                  pushCacheToken = Servant.Auth.Client.Token $ toSL t
+                  pushCacheSecret =
+                    Cachix.Push.PushSigningKey
+                      (Servant.Auth.Client.Token $ toSL t)
+                      k'
                 }

--- a/nix/cachix-api.nix
+++ b/nix/cachix-api.nix
@@ -15,6 +15,7 @@
 , jose
 , lens
 , memory
+, nix-narinfo
 , protolude
 , resourcet
 , servant
@@ -28,14 +29,13 @@
 , string-conv
 , swagger2
 , text
+, time
 , transformers
 }:
 mkDerivation {
   pname = "cachix-api";
-  version = "0.4.0";
-  sha256 = "5d8a2c8ec4b86c5199216ae85c7ee0cc1dcc349b8482e3dfe7d72b9b6db21c92";
-  isLibrary = true;
-  isExecutable = true;
+  version = "0.5.0";
+  sha256 = "9eeb6b8403f702a5983d558b29b67788a7bab9a09518b8dcec7f9ecdcddb6491";
   libraryHaskellDepends = [
     aeson
     base
@@ -51,20 +51,19 @@ mkDerivation {
     jose
     lens
     memory
+    nix-narinfo
     protolude
     resourcet
     servant
     servant-auth
     servant-auth-server
-    servant-auth-swagger
     servant-client
-    servant-swagger
     string-conv
     swagger2
     text
+    time
     transformers
   ];
-  executableHaskellDepends = [ aeson base protolude ];
   testHaskellDepends = [
     aeson
     base

--- a/nix/cachix.nix
+++ b/nix/cachix.nix
@@ -52,8 +52,8 @@
 }:
 mkDerivation {
   pname = "cachix";
-  version = "0.3.8";
-  sha256 = "469470df9e2383a4bcdf04c2c96a371bb4b5befd25c320c21c2e9a2f81f60558";
+  version = "0.5.1";
+  sha256 = "ab224ffddb6749296898957d949b563a368b2ef5cda07cefe33aa8fbe441b48f";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -113,6 +113,7 @@ mkDerivation {
     here
     hspec
     protolude
+    servant-auth-client
     temporary
   ];
   homepage = "https://github.com/cachix/cachix#readme";

--- a/nix/nix-narinfo.nix
+++ b/nix/nix-narinfo.nix
@@ -1,0 +1,30 @@
+{ mkDerivation
+, attoparsec
+, base
+, containers
+, filepath
+, hspec
+, QuickCheck
+, stdenv
+, text
+}:
+mkDerivation {
+  pname = "nix-narinfo";
+  version = "0.1.0.1";
+  sha256 = "900dab2ab230e291915f1a11f3b38c9e44f658c1988f713c0a92c1c53de4852f";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ attoparsec base containers text ];
+  executableHaskellDepends = [ attoparsec base text ];
+  testHaskellDepends = [
+    attoparsec
+    base
+    filepath
+    hspec
+    QuickCheck
+    text
+  ];
+  homepage = "https://github.com/sorki/nix-narinfo";
+  description = "Parse and render .narinfo files";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -30,6 +30,7 @@ let
                   self.callPackage ./cachix.nix {}
                 );
               cachix-api = self.callPackage ./cachix-api.nix {};
+              nix-narinfo = self.callPackage ./nix-narinfo.nix {};
 
               hercules-ci-api = callPkg super "hercules-ci-api" ../hercules-ci-api {};
               hercules-ci-api-agent = callPkg super "hercules-ci-api-agent" ../hercules-ci-api-agent {};

--- a/scripts/generate-nix
+++ b/scripts/generate-nix
@@ -4,10 +4,11 @@
 
 set -xe
 
-cabal2nix cabal://cachix-0.3.8 > nix/cachix.nix
-cabal2nix cabal://cachix-api-0.4.0 > nix/cachix-api.nix
+cabal2nix cabal://cachix-0.5.1 > nix/cachix.nix
+cabal2nix cabal://cachix-api-0.5.0 > nix/cachix-api.nix
 cabal2nix cabal://inline-c-0.9.0.0 > nix/haskell-inline-c.nix
 cabal2nix cabal://inline-c-cpp-0.4.0.2 >nix/haskell-inline-c-cpp.nix
+cabal2nix cabal://nix-narinfo-0.1.0.1 > nix/nix-narinfo.nix
 cabal2nix cabal://servant-websockets-2.0.0 > nix/servant-websockets.nix
 cabal2nix cabal://websockets-0.12.6.1 > nix/websockets.nix
 
@@ -18,4 +19,5 @@ pre-commit run --files \
   nix/servant-websockets.nix \
   nix/cachix.nix \
   nix/websockets.nix \
+  nix/nix-narinfo.nix \
   ;

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,14 +9,15 @@ packages:
   - tests/agent-test
 extra-deps:
   # REMINDER: sync with scripts/generate-nix
-  - cachix-0.3.8
+  - cachix-0.5.1
   # REMINDER: sync with scripts/generate-nix
-  - cachix-api-0.4.0@sha256:6f356eb0d5324cdddbb9911b473fd20bb37481e96481699ca1927afd41f4bb59,2983
+  - cachix-api-0.5.0
   - inline-c-0.9.0.0
   - inline-c-cpp-0.4.0.2
   - nix-derivation-1.0.2@sha256:dc1f13f89d37d4dcc7a46dbac7f6b4e8cd2877f4af99e35b9cb8255d08179bd4,3123
   - servant-auth-client-0.4.0.0@sha256:2875edeb95854422b87188d8385c5cf04333afcb92d8643f3af2b3a4642bddb8,3426
   - servant-websockets-2.0.0@sha256:6e9e3600bced90fd52ed3d1bf632205cb21479075b20d6637153cc4567000234,2253
+  - nix-narinfo-0.1.0.1@sha256:53d9ee364e14815b058c14e3056157f0245ba97972806ae3916a50f035955ea9,2111
 
 install-ghc: false  # we're using nixpkgs' ghc
 system-ghc: true    # nixpkgs ghc is perceived as 'system ghc'


### PR DESCRIPTION
(cherry picked from commit baf170e8680531022aa4bbd968ae864b325d9bba)

Does not include write token support because it breaks config semantics.