### PR TITLE
hercules-ci-cnix-store/cachix maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1610842533,
-        "narHash": "sha256-6hW8CML8RnNrRJMv7E56rXAhsCNgUM97HIVSqWxnO64=",
+        "lastModified": 1614535430,
+        "narHash": "sha256-kZwi0CooIOmFrk9eIteYSZIr4a4DVTEYV7UnURs6DSM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68398d2dd50efc2d878bf0f83bbc8bc323b6b0e0",
+        "rev": "0aeba64fb26e4defa0842a942757144659c6e29f",
         "type": "github"
       },
       "original": {

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker.hs
@@ -82,7 +82,7 @@ data HerculesState = HerculesState
   { drvsCompleted :: TVar (Map Text (UUID, BuildResult.BuildStatus)),
     drvsInProgress :: IORef (Set Text),
     herculesStore :: Ptr (Ref HerculesStore),
-    wrappedStore :: Ptr (Ref NixStore),
+    wrappedStore :: Store,
     shortcutChannel :: Chan (Maybe Event)
   }
 

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Effect.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Effect.hs
@@ -8,7 +8,7 @@ import GHC.ForeignPtr (ForeignPtr)
 import Hercules.Agent.Worker.Build.Prefetched (buildDerivation)
 import qualified Hercules.Agent.Worker.Build.Prefetched as Build
 import qualified Hercules.Agent.WorkerProtocol.Command.Effect as Command.Effect
-import Hercules.CNix (NixStore, Ref)
+import Hercules.CNix (Store)
 import qualified Hercules.CNix as CNix
 import Hercules.CNix.Store.Context (Derivation)
 import qualified Hercules.Effect as Effect
@@ -16,13 +16,13 @@ import Katip (KatipContext)
 import Protolude
 import UnliftIO.Directory (getCurrentDirectory)
 
-runEffect :: (MonadIO m, KatipContext m, MonadThrow m) => Ptr (Ref NixStore) -> Command.Effect.Effect -> m ExitCode
+runEffect :: (MonadIO m, KatipContext m, MonadThrow m) => Store -> Command.Effect.Effect -> m ExitCode
 runEffect store command = do
   derivation <- prepareDerivation store command
   dir <- getCurrentDirectory
   Effect.runEffect derivation (Command.Effect.token command) (Command.Effect.secretsPath command) (Command.Effect.apiBaseURL command) dir
 
-prepareDerivation :: MonadIO m => Ptr (Ref NixStore) -> Command.Effect.Effect -> m (ForeignPtr Derivation)
+prepareDerivation :: MonadIO m => Store -> Command.Effect.Effect -> m (ForeignPtr Derivation)
 prepareDerivation store command = do
   let extraPaths = Command.Effect.inputDerivationOutputPaths command
       drvPath = encodeUtf8 $ Command.Effect.drvPath command

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/HerculesStore.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/HerculesStore.hs
@@ -19,7 +19,9 @@ import Hercules.Agent.Worker.HerculesStore.Context
   ( HerculesStore,
     context,
   )
-import Hercules.CNix.Store.Context (NixStore, Ref)
+import Hercules.CNix (Store)
+import Hercules.CNix.Expr (Store (Store))
+import Hercules.CNix.Store.Context (Ref)
 import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Inline.Cpp.Exceptions as C
 import Protolude
@@ -48,10 +50,10 @@ C.include "hercules-aliases.h"
 C.using "namespace nix"
 
 withHerculesStore ::
-  Ptr (Ref NixStore) ->
+  Store ->
   (Ptr (Ref HerculesStore) -> IO a) ->
   IO a
-withHerculesStore wrappedStore =
+withHerculesStore (Store wrappedStore) =
   bracket
     ( liftIO
         [C.block| refHerculesStore* {
@@ -62,7 +64,7 @@ withHerculesStore wrappedStore =
     )
     (\x -> liftIO [C.exp| void { delete $(refHerculesStore* x) } |])
 
-nixStore :: Ptr (Ref HerculesStore) -> Ptr (Ref NixStore)
+nixStore :: Ptr (Ref HerculesStore) -> Store
 nixStore = coerce
 
 printDiagnostics :: Ptr (Ref HerculesStore) -> IO ()

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Env.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Env.hs
@@ -1,7 +1,7 @@
 module Hercules.Agent.Cachix.Env where
 
 import qualified Cachix.Client.Push as Cachix
-import Cachix.Client.Store (Store)
+import Hercules.CNix.Store (Store)
 import Hercules.Formats.CachixCache (CachixCache)
 import Protolude
 import Servant.Client (ClientEnv)

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Init.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cachix/Init.hs
@@ -5,11 +5,11 @@ module Hercules.Agent.Cachix.Init where
 import Cachix.Client.Env (cachixVersion)
 import qualified Cachix.Client.Push as Cachix.Push
 import qualified Cachix.Client.Secrets as Cachix.Secrets
-import qualified Cachix.Client.Store as Cachix.Store
 import Cachix.Client.URI (defaultCachixBaseUrl)
 import qualified Data.Map as M
 import Hercules.Agent.Cachix.Env as Env
 import qualified Hercules.Agent.Config as Config
+import Hercules.CNix.Store (openStore)
 import Hercules.Error
 import qualified Hercules.Formats.CachixCache as CachixCache
 import qualified Katip as K
@@ -35,7 +35,7 @@ newEnv _config cks = do
   K.katipAddContext (K.sl "caches" (M.keys cks)) $
     K.logLocM K.DebugS ("Cachix init " <> K.logStr (show (M.keys cks) :: Text))
   pcs <- liftIO $ toPushCaches cks
-  store <- liftIO Cachix.Store.openStore
+  store <- liftIO openStore
   httpManager <- newTlsManagerWith customManagerSettings
   pure
     Env.Env

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Nix/RetrieveDerivationInfo.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Nix/RetrieveDerivationInfo.hs
@@ -8,12 +8,11 @@ import Hercules.API.Agent.Evaluate.EvaluateEvent.DerivationInfo
   )
 import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.DerivationInfo as DerivationInfo
 import Hercules.CNix
-import Hercules.CNix.Store.Context (Derivation)
 import Protolude
 
 retrieveDerivationInfo ::
   MonadIO m =>
-  Ptr (Ref NixStore) ->
+  Store ->
   DerivationInfo.DerivationPathText ->
   m DerivationInfo
 retrieveDerivationInfo store drvPath = liftIO $ do

--- a/hercules-ci-cli/src/Hercules/CLI/Effect.hs
+++ b/hercules-ci-cli/src/Hercules/CLI/Effect.hs
@@ -16,9 +16,9 @@ import Hercules.CLI.Nix (attrByPath, callCiNix, ciNixAttributeCompleter, withNix
 import Hercules.CLI.Options (flatCompleter, mkCommand)
 import Hercules.CLI.Project (ProjectPath, getProjectIdAndPath, projectOption)
 import Hercules.CLI.Secret (getSecretsFilePath)
-import Hercules.CNix (NixStore, Ref, getDerivationInputs)
+import Hercules.CNix (Store)
 import Hercules.CNix.Expr (Match (IsAttrs), Value (rtValue), getAttrBool, getDrvFile, match)
-import Hercules.CNix.Store (buildPaths)
+import Hercules.CNix.Store (buildPaths, getDerivationInputs)
 import qualified Hercules.CNix.Store as CNix
 import Hercules.CNix.Store.Context (Derivation)
 import Hercules.Effect (runEffect)
@@ -80,7 +80,7 @@ runParser = do
           runKatipContextT logEnv () mempty $ runEffect derivation (Sensitive token) secretsJson apiBaseURL workDir
         throwIO exitCode
 
-prepareDerivation :: MonadIO m => Ptr (Ref NixStore) -> ByteString -> m (ForeignPtr Derivation)
+prepareDerivation :: MonadIO m => Store -> ByteString -> m (ForeignPtr Derivation)
 prepareDerivation store drvPath = do
   derivation <- liftIO $ CNix.getDerivation store drvPath
   inputs <- liftIO $ getDerivationInputs derivation

--- a/hercules-ci-cnix-expr/src/Hercules/CNix/Expr.hs
+++ b/hercules-ci-cnix-expr/src/Hercules/CNix/Expr.hs
@@ -8,10 +8,7 @@ module Hercules.CNix.Expr
     rawValueType,
     module Hercules.CNix.Store,
     module Hercules.CNix.Expr.Typed,
-    type NixStore,
     type EvalState,
-    type Ref,
-    type SecretKey,
   )
 where
 
@@ -116,10 +113,10 @@ logInfo t = do
   }|]
 
 withEvalState ::
-  Ptr (Ref NixStore) ->
+  Store ->
   (Ptr EvalState -> IO a) ->
   IO a
-withEvalState store =
+withEvalState (Store store) =
   bracket
     ( liftIO
         [C.throwBlock| EvalState* {
@@ -131,10 +128,10 @@ withEvalState store =
 
 withEvalStateConduit ::
   MonadResource m =>
-  Ptr (Ref NixStore) ->
+  Store ->
   (Ptr EvalState -> ConduitT i o m r) ->
   ConduitT i o m r
-withEvalStateConduit store =
+withEvalStateConduit (Store store) =
   bracketP
     ( liftIO
         [C.throwBlock| EvalState* {

--- a/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
+++ b/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
@@ -55,7 +55,6 @@ library
     , inline-c
     , inline-c-cpp
     , bytestring
-    , cachix >= 0.5.1
     , conduit
     , containers
     , protolude

--- a/hercules-ci-cnix-store/include/hercules-ci-cnix/store.hxx
+++ b/hercules-ci-cnix-store/include/hercules-ci-cnix/store.hxx
@@ -7,3 +7,5 @@ typedef nix::Strings::iterator StringsIterator;
 typedef nix::DerivationOutputs::iterator DerivationOutputsIterator;
 typedef nix::DerivationInputs::iterator DerivationInputsIterator;
 typedef nix::StringPairs::iterator StringPairsIterator;
+typedef nix::PathSet::iterator PathSetIterator;
+typedef nix::ref<const nix::ValidPathInfo> refValidPathInfo;

--- a/hercules-ci-cnix-store/src/Hercules/CNix.hs
+++ b/hercules-ci-cnix-store/src/Hercules/CNix.hs
@@ -5,9 +5,6 @@
 module Hercules.CNix
   ( module Hercules.CNix,
     module Hercules.CNix.Store,
-    type NixStore,
-    type Ref,
-    type SecretKey,
   )
 where
 
@@ -16,7 +13,6 @@ where
 -- TODO: Map Nix-specific C++ exceptions to a CNix exception type
 
 import Hercules.CNix.Store
-import Hercules.CNix.Store.Context
 import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Inline.Cpp.Exceptions as C
 import Protolude hiding (evalState, throwIO)

--- a/hercules-ci-cnix-store/src/Hercules/CNix/Store/Context.hs
+++ b/hercules-ci-cnix-store/src/Hercules/CNix/Store/Context.hs
@@ -2,13 +2,8 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Hercules.CNix.Store.Context
-  ( module Hercules.CNix.Store.Context,
-    NixStore,
-  )
-where
+module Hercules.CNix.Store.Context where
 
-import Cachix.Client.Store.Context (NixStore)
 import Data.ByteString.Unsafe (unsafePackMallocCString)
 import qualified Data.Map as M
 import qualified Foreign.C.String
@@ -17,9 +12,29 @@ import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Types as C
 import Protolude
 
+-- | A C++ STL @std::set@, to be used in phantom types.
+data StdSet a
+
+-- | A C++ STL @<a>::iterator@
+data Iterator a
+
+-- | A C++ @std::string@
+data StdString
+
+-- | A Nix @ref@, to be used in phantom types.
 data Ref a
 
+-- | A Nix @PathSet@ aka @std::set<Path>@ (Nix <= 2.3.*: aka @std::set<std::string>>@)
+type PathSet = StdSet StdString
+
+type PathSetIterator = Iterator StdString
+
+-- | A Nix @Strings@ aka @std::list<std::string>@
 data Strings
+
+data NixStore
+
+data ValidPathInfo
 
 data Derivation
 
@@ -41,6 +56,9 @@ context =
     <> C.bsCtx
       { C.ctxTypesTable =
           M.singleton (C.TypeName "refStore") [t|Ref NixStore|]
+            <> M.singleton (C.TypeName "refValidPathInfo") [t|Ref ValidPathInfo|]
+            <> M.singleton (C.TypeName "PathSet") [t|PathSet|]
+            <> M.singleton (C.TypeName "PathSetIterator") [t|PathSetIterator|]
             <> M.singleton (C.TypeName "Strings") [t|Strings|]
             <> M.singleton (C.TypeName "StringsIterator") [t|StringsIterator|]
             <> M.singleton (C.TypeName "StringPairs") [t|StringPairs|]

--- a/nix/cachix.nix
+++ b/nix/cachix.nix
@@ -14,8 +14,10 @@
 , dhall
 , directory
 , ed25519
+, fetchgit
 , filepath
 , fsnotify
+, hercules-ci-cnix-store
 , here
 , hspec
 , hspec-discover
@@ -25,6 +27,7 @@
 , http-types
 , inline-c
 , inline-c-cpp
+, lib
 , lzma-conduit
 , megaparsec
 , memory
@@ -43,7 +46,6 @@
 , servant-client
 , servant-client-core
 , servant-conduit
-, stdenv
 , stm
 , temporary
 , text
@@ -55,7 +57,13 @@
 mkDerivation {
   pname = "cachix";
   version = "0.6.0";
-  sha256 = "d49ad3f405b1ddcceda0f11319f78bcebf5c9a677fd84d087b9b5e7bad98c3ab";
+  src = fetchgit {
+    url = "https://github.com/hercules-ci/cachix";
+    sha256 = "07xnq20rrnr0c7kyq8ngg3dzd4s11i2gzmvzm7nmg9sqwjgr40j4";
+    rev = "84a0a55359a58030ca604117faa8883ec8632009";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/cachix; echo source root reset to $sourceRoot";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -75,6 +83,7 @@ mkDerivation {
     ed25519
     filepath
     fsnotify
+    hercules-ci-cnix-store
     here
     http-client
     http-client-tls
@@ -122,5 +131,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/cachix/cachix#readme";
   description = "Command line client for Nix binary cache hosting https://cachix.org";
-  license = stdenv.lib.licenses.asl20;
+  license = lib.licenses.asl20;
 }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -156,8 +156,8 @@ let
                     '';
                 }
                 );
-              hercules-ci-cnix-expr = haskell.lib.disableLibraryProfiling (callPkg super "hercules-ci-cnix-expr" ../hercules-ci-cnix-expr { bdw-gc = pkgs.boehmgc-hercules; });
-              hercules-ci-cnix-store = haskell.lib.disableLibraryProfiling (callPkg super "hercules-ci-cnix-store" ../hercules-ci-cnix-store { });
+              hercules-ci-cnix-expr = callPkg super "hercules-ci-cnix-expr" ../hercules-ci-cnix-expr { bdw-gc = pkgs.boehmgc-hercules; };
+              hercules-ci-cnix-store = callPkg super "hercules-ci-cnix-store" ../hercules-ci-cnix-store { };
 
               websockets = updateTo "0.12.6.1" super.websockets (self.callPackage ./websockets.nix { });
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -42,12 +42,7 @@ let
             {
               # 2020-11-21: cachix + chachix-api needs a patch for ghc 8.10 compat
               # https://github.com/cachix/cachix/pull/331
-              cachix =
-                updateTo "0.6.0" super.cachix (
-                  haskell.lib.disableLibraryProfiling (
-                    self.callPackage ./cachix.nix { }
-                  )
-                );
+              cachix = self.callPackage ./cachix.nix { };
               cachix-api =
                 updateTo "0.6.0" super.cachix-api (self.callPackage ./cachix-api.nix { });
 

--- a/scripts/generate-nix
+++ b/scripts/generate-nix
@@ -4,7 +4,7 @@
 
 set -xe
 
-cabal2nix cabal://cachix-0.6.0 > nix/cachix.nix
+# cabal2nix cabal://cachix-0.6.0 > nix/cachix.nix
 cabal2nix cabal://cachix-api-0.6.0 > nix/cachix-api.nix
 cabal2nix cabal://nix-narinfo-0.1.0.1 > nix/nix-narinfo.nix
 cabal2nix cabal://servant-websockets-2.0.0 > nix/servant-websockets.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,17 +17,12 @@ extra-deps:
       # gc root: refs/tags/0.16.1-completion-control-1
       c4d558158dcf97bb39b409c24f519b2358c64b6f
   # REMINDER: sync with scripts/generate-nix
-  # - git: https://github.com/hercules-ci/cachix.git
-  #   commit:
-  #     # ghc >=8.10:
-  #     9cfe586a9ed173f87d741063bced024335e394ba
-  #     # ghc < 8.10:
-  #     # 33a040faa8c5c0d7d27b8147fd95245b3808bd98
-  #   subdirs:
-  #     - cachix
-  #     - cachix-api
-  - cachix-0.6.0
-  - cachix-api-0.6.0
+  - git: https://github.com/hercules-ci/cachix.git
+    commit:
+      84a0a55359a58030ca604117faa8883ec8632009
+    subdirs:
+      - cachix
+      - cachix-api
   - inline-c-0.9.0.0
   - inline-c-cpp-0.4.0.2
   - ListLike-4.7.4@sha256:613b2967df738010e8f6f6b7c47d615f6fe42081f68eba7f946d5de7552aa8a4,3778

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-01-01
+resolver: lts-17.5
 
 # paths to local packages
 packages:


### PR DESCRIPTION
 - Make hercules-ci-cnix-store suitable for cachix
 - Use patched cachix to use that lib, removing unsafeCoerce
 - Update to GHC 8.10.4 and Stackage LTS 17.5
 - Enable some profiling builds