### PR TITLE
nix/flake-compat.nix: Add hint because Nix 2.4 breaks flake-compat

### DIFF
--- a/nix/flake-compat.nix
+++ b/nix/flake-compat.nix
@@ -5,5 +5,18 @@ let
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
     sha256 = narHash;
   };
+  warn = msg: builtins.trace "[1;31mwarning: ${msg}[0m";
+  probablyPure = builtins.getEnv "PATH" == "" && builtins.getEnv "NIX_PATH" == "";
+  warned =
+    if builtins?getFlake && probablyPure
+    then
+      warn
+        ''It seems that you are using Nix in pure evaluation mode and your Nix supports flakes.
+        Please use the flake and its attributes instead of importing files by
+        path.
+        Nix 2.4 can not load the flake from the path of the flake, so you have
+        to use the modules and packages in the flake attributes; e.g.
+          inputs.hercules-ci-agent.nixosModules.agent-service''
+    else x: x;
 in
-import flake-compat { src = ../.; }
+warned import flake-compat { src = ../.; }


### PR DESCRIPTION
Closes #341 