### PR TITLE
Log client robust

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Logger.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Logger.hs
@@ -265,6 +265,7 @@ withLoggerConduit logger io = withAsync (logger popper) $ \popperAsync ->
 filterProgress :: Monad m => ConduitT (Flush LogEntry) (Flush LogEntry) m ()
 filterProgress = filterC \case
   Chunk LogEntry.Result {rtype = LogEntry.ResultTypeProgress} -> False
+  Chunk LogEntry.Result {rtype = LogEntry.ResultTypeSetExpected} -> False
   _ -> True
 
 nubProgress :: Monad m => ConduitT (Flush LogEntry) (Flush LogEntry) m ()

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Conduit.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Conduit.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Hercules.Agent.Worker.Conduit where
+
+import Data.Conduit (ConduitT, await, awaitForever, yield, (.|))
+import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
+import qualified Data.Sequence as Seq
+import Protolude hiding (pred, yield)
+
+tailC :: Monad m => Int -> ConduitT i i m ()
+tailC n = do
+  buf <- sinkTail n
+  for_ buf yield
+
+-- | Return the last @n@ items
+sinkTail :: Monad m => Int -> ConduitT i o m (Seq i)
+sinkTail n = do
+  doBuffer mempty
+  where
+    doBuffer st =
+      await >>= \case
+        Nothing -> pure st
+        Just item -> doBuffer $! (Seq.drop (length st - n + 1) st Seq.:|> item)
+
+-- | Take at most @n@ items that satisfy the predicate, then stop consuming,
+-- even if the next item does not match the predicate.
+takeCWhileStopEarly :: Monad m => (i -> Bool) -> Int -> ConduitT i i m ()
+takeCWhileStopEarly counts = go
+  where
+    go limit | limit <= 0 = pass
+    go limit =
+      await >>= traverse_ \item -> do
+        yield item
+        if item & counts
+          then go (limit - 1)
+          else go limit
+
+countProduction :: (Num n, MonadIO m) => (i -> Bool) -> IORef n -> ConduitT i i m ()
+countProduction pred counter = awaitForever (\i -> increment i *> yield i)
+  where
+    increment i | pred i = liftIO $ modifyIORef counter (+ 1)
+    increment _ = pass
+
+withInputProductionCount :: MonadIO m => (i -> Bool) -> ConduitT i o m a -> ConduitT i o m (Int, a)
+withInputProductionCount pred conduit = do
+  counter <- liftIO $ newIORef 0
+  r <- countProduction pred counter .| conduit
+  (,r) <$> liftIO (readIORef counter)
+
+withMessageLimit ::
+  MonadIO m =>
+  (a -> Bool) ->
+  -- | First limit
+  Int ->
+  -- | Max tail part limit
+  Int ->
+  -- | What to do when truncation may start
+  ConduitT a a m () ->
+  -- | What to do before yielding a truncated tail
+  (Int -> ConduitT a a m ()) ->
+  -- | What to do after yielding a truncated tail
+  (Int -> ConduitT a a m ()) ->
+  ConduitT a a m ()
+withMessageLimit pred firstLimit tailLimit afterFirst beforeTail afterTail = do
+  takeCWhileStopEarly pred firstLimit
+  afterFirst
+  (n, x) <- withInputProductionCount pred do
+    sinkTail tailLimit
+  let between = n - Seq.length x
+  when (between > 0) do
+    beforeTail between
+  for_ x yield
+  when (between > 0) do
+    afterTail between

--- a/hercules-ci-agent/hercules-ci-agent.cabal
+++ b/hercules-ci-agent/hercules-ci-agent.cabal
@@ -268,6 +268,7 @@ executable hercules-ci-agent-worker
       Hercules.Agent.Worker.Build.Prefetched
       Hercules.Agent.Worker.Build.Logger
       Hercules.Agent.Worker.Build.Logger.Context
+      Hercules.Agent.Worker.Conduit
       Hercules.Agent.Worker.Effect
       Hercules.Agent.Worker.Env
       Hercules.Agent.Worker.Error
@@ -362,6 +363,9 @@ test-suite hercules-test
       Hercules.Agent.Nix.RetrieveDerivationInfoSpec
       Hercules.Agent.WorkerProcess
       Hercules.Agent.WorkerProcessSpec
+      Hercules.Agent.Worker.Conduit
+      Hercules.Agent.Worker.ConduitSpec
+      Hercules.Agent.Worker.STM
       Hercules.Agent.Worker.STMSpec
       Hercules.Secrets
       Hercules.SecretsSpec

--- a/hercules-ci-agent/hercules-ci-agent.cabal
+++ b/hercules-ci-agent/hercules-ci-agent.cabal
@@ -217,6 +217,7 @@ executable hercules-ci-agent
     , exceptions
     , filepath
     , hercules-ci-agent
+    , hercules-ci-api
     , hercules-ci-api-core == 0.1.4.0
     , hercules-ci-api-agent == 0.4.4.0
     , hostname

--- a/hercules-ci-agent/test/Hercules/Agent/Worker/ConduitSpec.hs
+++ b/hercules-ci-agent/test/Hercules/Agent/Worker/ConduitSpec.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Hercules.Agent.Worker.ConduitSpec where
+
+import Data.Conduit
+import Data.Conduit.Combinators (sinkList)
+import Data.Conduit.List (sourceList)
+import Hercules.Agent.Worker.Conduit (tailC, takeCWhileStopEarly, withMessageLimit)
+import Protolude hiding (yield)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "tailC" do
+    it "can produce an empty output" do
+      l <- runConduit (pass .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` []
+    it "can produce a short output (1)" do
+      l <- runConduit (sourceList [1] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [1]
+    it "can produce a short output (2)" do
+      l <- runConduit (sourceList [1, 2] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [1, 2]
+    it "can produce a matching output (3)" do
+      l <- runConduit (sourceList [1 .. 3] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [1, 2, 3]
+    it "can produce a tail output (4)" do
+      l <- runConduit (sourceList [1 .. 4] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [2, 3, 4]
+    it "can produce a tail output (5)" do
+      l <- runConduit (sourceList [1 .. 5] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [3, 4, 5]
+    it "can produce a tail output (100)" do
+      l <- runConduit (sourceList [1 .. 100] .| tailC 3 .| sinkList)
+      (l :: [Int]) `shouldBe` [98, 99, 100]
+  describe "takeCWhileStopEarly" do
+    it "works for example" do
+      l <- runConduit (sourceList [1 .. 10] .| takeCWhileStopEarly even 2 .| sinkList)
+      (l :: [Int]) `shouldBe` [1, 2, 3, 4]
+  describe "withMessageLimit" do
+    let exampleConduit = do
+          withMessageLimit (const True) 20 10 pass (\between -> yield (-1 * between)) yield
+
+    it "works for input 0" do
+      r <- runConduit do
+        sourceList ([] :: [Int])
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` []
+
+    it "works for input 1" do
+      r <- runConduit do
+        sourceList [1 .. 12 :: Int]
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` [1 .. 12]
+
+    it "works for input 2" do
+      r <- runConduit do
+        sourceList [1 .. 22 :: Int]
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` [1 .. 22]
+
+    it "works for input 3" do
+      r <- runConduit do
+        sourceList [1 .. 30 :: Int]
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` [1 .. 30]
+
+    it "works for input 4" do
+      r <- runConduit do
+        sourceList [1 .. 31 :: Int]
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` [1 .. 20] <> [-1] <> [22 .. 31] <> [1]
+
+    it "works for input 5" do
+      r <- runConduit do
+        sourceList [1 .. 100 :: Int]
+          .| exampleConduit
+          .| sinkList
+      r `shouldBe` ([1 .. 20] <> [-70] <> [91 .. 100]) <> [70]

--- a/hercules-ci-agent/test/Spec.hs
+++ b/hercules-ci-agent/test/Spec.hs
@@ -5,6 +5,7 @@ where
 
 import qualified Hercules.Agent.Nix.RetrieveDerivationInfoSpec
 import qualified Hercules.Agent.NixPathSpec
+import qualified Hercules.Agent.Worker.ConduitSpec
 import qualified Hercules.Agent.Worker.STMSpec
 import qualified Hercules.Agent.WorkerProcessSpec
 import qualified Hercules.SecretsSpec
@@ -17,3 +18,4 @@ spec = do
   describe "Hercules.Agent.Nix.RetrieveDerivationInfo" Hercules.Agent.Nix.RetrieveDerivationInfoSpec.spec
   describe "Hercules.Secret" Hercules.SecretsSpec.spec
   describe "Hercules.Agent.Worker.STMSpec" Hercules.Agent.Worker.STMSpec.spec
+  describe "Hercules.Agent.Worker.Conduit" Hercules.Agent.Worker.ConduitSpec.spec

--- a/hercules-ci-api-agent/src/Hercules/API/Logs/LogEntry.hs
+++ b/hercules-ci-api-agent/src/Hercules/API/Logs/LogEntry.hs
@@ -23,6 +23,9 @@ newtype ResultType = ResultType Word64
 pattern ResultTypeProgress :: ResultType
 pattern ResultTypeProgress = ResultType 105
 
+pattern ResultTypeSetExpected :: ResultType
+pattern ResultTypeSetExpected = ResultType 106
+
 pattern ResultTypeBuildLogLine :: ResultType
 pattern ResultTypeBuildLogLine = ResultType 101
 


### PR DESCRIPTION
- Add client side log limit.
- Remove remaining (hidden) progress message from log stream.
- Add task id and more to worker process log context.
- Add a 30s handshake timeout, so the socket can't wait indefinitely for connection. Existing "ack" timeout and pings take over from there.