### PR TITLE
Nix 2.9 buildable

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Evaluate.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Evaluate.hs
@@ -470,7 +470,7 @@ simpleWalk evalEnv initialThunk = do
               if isDeriv
                 then walkDerivation store evalState False path attrValue
                 else do
-                  attrs <- liftIO $ getAttrs attrValue
+                  attrs <- liftIO $ getAttrs evalState attrValue
                   void $
                     flip M.traverseWithKey attrs $
                       \name value ->
@@ -605,7 +605,7 @@ walk evalEnv autoArgs v0 = withIFDQueue evalEnv \enqueue ->
                           x <- liftIO (autoCallFunction evalState v autoArgs)
                           walk' True path (depthRemaining - 1) x
                         else do
-                          attrs <- liftIO $ getAttrs attrValue
+                          attrs <- liftIO $ getAttrs evalState attrValue
                           void $
                             flip M.traverseWithKey attrs $
                               \name value ->

--- a/hercules-ci-cli/src/Hercules/CLI/Nix.hs
+++ b/hercules-ci-cli/src/Hercules/CLI/Nix.hs
@@ -102,7 +102,7 @@ ciNixAttributeCompleter = mkTextCompleter \partial -> do
           Just focusValue -> do
             match' evalState focusValue >>= \case
               IsAttrs attrset -> do
-                attrs <- getAttrs attrset
+                attrs <- getAttrs evalState attrset
                 isDeriv <- isDerivation evalState focusValue
                 if isDeriv
                   then pure [(mempty {Optparse.cioFiles = False}, prefixStr)]

--- a/hercules-ci-cnix-expr/src/Hercules/CNix/Expr/Schema.hs
+++ b/hercules-ci-cnix-expr/src/Hercules/CNix/Expr/Schema.hs
@@ -318,7 +318,8 @@ requireDict name as = do
 
 dictionaryToMap :: MonadEval m => PSObject (Dictionary w) -> m (Map ByteString (PSObject w))
 dictionaryToMap dict = do
-  (liftIO . Expr.getAttrs =<< check dict)
+  es <- ask
+  (liftIO . Expr.getAttrs es =<< check dict)
     <&> M.mapWithKey
       ( \name b ->
           PSObject {value = b, provenance = Attribute (provenance dict) (decodeUtf8With lenientDecode name)}

--- a/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
+++ b/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
@@ -76,8 +76,8 @@ library
   include-dirs:
       include
   pkgconfig-depends:
-      nix-store >= 2.4 && < 2.9
-    , nix-main >= 2.4 && < 2.9
+      nix-store >= 2.4 && < 2.10
+    , nix-main >= 2.4 && < 2.10
   install-includes:
       hercules-ci-cnix/store.hxx
   hs-source-dirs: src


### PR DESCRIPTION
2.9.0 is delayed in Nixpkgs because of a crash, so won't merge the actual pin upgrade until we have 2.9.1.
Can probably merge the CPP stuff before that though.