### PR TITLE
readme: block quote the final commands to render better

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Build `nixUnstable` with cabal:
 
 * change `../nix/shellFor-cabal.nix` to pick the right job from the `ci` param, then
 * run:
-
-    cd hercules-ci-cnix-store-expr
-    nix-shell ../nix/shellFor-cabal.nix
-    cabal v2-test -fnix-2_4 --enable-debug-info --disable-library-stripping --disable-executable-stripping
+```
+cd hercules-ci-cnix-store-expr
+nix-shell ../nix/shellFor-cabal.nix
+cabal v2-test -fnix-2_4 --enable-debug-info --disable-library-stripping --disable-executable-stripping
+```


### PR DESCRIPTION
Github markdown doesn't seem to support multiline indented codeblocks?