### PR TITLE
Support building with old & new cabal2nix

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -60,6 +60,7 @@ let
     '';
 
   callPkg = super: name: srcPath: args: buildFromCabalSdist (super.callCabal2nix name srcPath args);
+  callPkgOpts = opts: super: name: srcPath: args: buildFromCabalSdist (super.callCabal2nixWithOptions name srcPath opts args);
 
   updateTo = v: stdPkg: altPkg:
     if lib.versionAtLeast stdPkg.version v
@@ -188,7 +189,7 @@ let
               hercules-ci-cnix-expr = addBuildTool
                 (
                   addBuildDepends
-                    (callPkg super "hercules-ci-cnix-expr" ../hercules-ci-cnix-expr {
+                    (callPkgOpts "--extra-arguments nix-cmd" super "hercules-ci-cnix-expr" ../hercules-ci-cnix-expr {
                       inherit nix;
                       # https://github.com/NixOS/cabal2nix/pull/546
                       nix-cmd = nix;


### PR DESCRIPTION
I pull in the hercules-ci overlay and noticed that I couldn't update nixpkgs because https://github.com/NixOS/cabal2nix/pull/546 made its way to the nixos-unstable branch.