### PR TITLE
hercules-ci-agent/nixos: Increase stack limit

### DIFF
--- a/hercules-ci-agent/CHANGELOG.md
+++ b/hercules-ci-agent/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+ - Work around excessive stack use by libstdc++ regex [issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164)
+   The new limit of 256 MiB stack allows larger string inputs to be used.
+   This bug was triggered by purs-nix and possibly other Nix expression libraries that parse substantial files.
+
 ## [0.9.7] - 2022-07-21
 
 ### Added

--- a/internal/nix/nixos/default.nix
+++ b/internal/nix/nixos/default.nix
@@ -38,6 +38,11 @@ in
         # If a worker goes OOM, don't kill the main process. It needs to
         # report the failure and it's unlikely to be part of the problem.
         OOMPolicy = "continue";
+
+        # Work around excessive stack use by libstdc++ regex
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164
+        # A 256 MiB stack allows between 400 KiB and 1.5 MiB file to be matched by ".*".
+        LimitSTACK = 256 * 1024 * 1024;
       };
     };
 

--- a/internal/nix/nixos/multi.nix
+++ b/internal/nix/nixos/multi.nix
@@ -80,6 +80,11 @@ let
                 # If a worker goes OOM, don't kill the main process. It needs to
                 # report the failure and it's unlikely to be part of the problem.
                 OOMPolicy = "continue";
+
+                # Work around excessive stack use by libstdc++ regex
+                # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164
+                # A 256 MiB stack allows between 400 KiB and 1.5 MiB file to be matched by ".*".
+                LimitSTACK = 256 * 1024 * 1024;
               };
             };
 


### PR DESCRIPTION
Didn't get `pkgsLLVM` or `libcxxStdenv` or `clangStdenv` to work, so we're stuck with a bad regex implementation for the time being.
Changing the stack size limit is sufficient for purs-nix to work. Fixes #445 

>  - Work around excessive stack use by libstdc++ regex [issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86164)
   The new limit of 256 MiB stack allows larger string inputs to be used.
   This bug was triggered by purs-nix and possibly other Nix expression libraries that parse substantial files.