### PR TITLE
Retry when pushing to a nix cache

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
@@ -45,7 +45,7 @@ push ::
   -- | Number of concurrent upload threads
   Int ->
   App ()
-push cacheName paths concurrency = katipAddContext (sl "cacheName" cacheName) do
+push cacheName paths concurrency = katipAddNamespace "Push" $ katipAddContext (sl "cacheName" cacheName) do
   caches <- asks Env.binaryCaches
   let maybeNix =
         Config.nixCaches caches & M.lookup cacheName & fmap \cache ->

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Cache.hs
@@ -16,6 +16,7 @@ import Hercules.CNix.Std.Set (StdSet, toListFP)
 import qualified Hercules.CNix.Std.Set as Std.Set
 import Hercules.CNix.Store (StorePath)
 import qualified Hercules.CNix.Store as Store
+import Hercules.Error (defaultRetry)
 import qualified Hercules.Formats.NixCache as NixCache
 import Katip
 import Protolude
@@ -68,7 +69,7 @@ nixPush cacheConf paths _concurrency = do
     katipAddContext (sl "num-signatures" signed <> sl "num-paths" total) $
       logLocM DebugS "Signed"
     liftIO $ CNix.clearPathInfoCache store
-    CNix.withStoreFromURI (NixCache.storeURI cacheConf) $ \cache -> do
+    defaultRetry . CNix.withStoreFromURI (NixCache.storeURI cacheConf) $ \cache -> do
       liftIO (CNix.copyClosure store cache paths)
 
 signClosure :: CNix.Store -> ForeignPtr CNix.SecretKey -> StdSet Store.NixStorePath -> IO (Sum Int, Sum Int)


### PR DESCRIPTION
Neither ssh nor ssh-ng seem to retry sufficiently for a mass-rebuild to complete.