### PR TITLE
default-herculesCI-for-flake.nix: Fix darwinConfigurations + ciSystems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -510,7 +510,7 @@
                 // lib.optionalAttrs (system == "x86_64-linux") {
                   evalTests =
                     (import ./tests/default-herculesCI-for-flake-test.nix
-                      { inherit lib; }).test
+                      { inherit (nixpkgs) lib; }).test
                       pkgs.emptyFile;
                 };
             };

--- a/hercules-ci-agent/data/default-herculesCI-for-flake.nix
+++ b/hercules-ci-agent/data/default-herculesCI-for-flake.nix
@@ -52,24 +52,24 @@ let
     then attrs: attrs
     else intersectAttrs ciSystems;
 
-  getSystem = sys:
-    sys._module.args.pkgs.stdenv.buildPlatform.system
-      or sys.config.system.build.toplevel.stdenv.buildPlatform.system
-      or sys.config.nixpkgs.localSystem.system
-      or sys.config.nixpkgs.system
-  ;
+  getSystemNixDarwin = sys: sys.config.nixpkgs.system;
 
-  isEnabledSystemConfig = ciSystems:
+  getSystemNixOS = sys:
+    if sys?options.nixpkgs.hostPlatform && sys.options.nixpkgs.hostPlatform.isDefined
+    then sys.config.nixpkgs.buildPlatform.system
+    else sys.config.nixpkgs.localSystem.system or sys.config.nixpkgs.system;
+
+  isEnabledSystemConfig = getter: ciSystems:
     if ciSystems == null
     then sys: true
     else
       sys:
-      hasAttr (getSystem sys) ciSystems;
+      hasAttr (getter sys) ciSystems;
 
-  filterSystemConfigs = ciSystems: filterAttrs (k: v:
-    if isEnabledSystemConfig ciSystems v
+  filterSystemConfigs = getter: ciSystems: filterAttrs (k: v:
+    if isEnabledSystemConfig getter ciSystems v
     then true
-    else builtins.trace "Ignoring flake attribute ${k} (system ${getSystem v} not in ciSystems)" false);
+    else builtins.trace "Ignoring flake attribute ${k} (system ${getter v} not in ciSystems)" false);
 
   translateFlakeAttr = args: k: v:
     if translations?${k}
@@ -172,8 +172,8 @@ let
       devShell = forSystems (sys: translateShell);
       devShells = forSystems (sys: mapAttrs (k: translateShell));
       apps = forSystems (sys: mapAttrs (k: checkApp));
-      nixosConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs args.ciSystems attrs);
-      darwinConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs args.ciSystems attrs);
+      nixosConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs getSystemNixOS args.ciSystems attrs);
+      darwinConfigurations = args: attrs: mapAttrs (k: sys: { config.system.build.toplevel = sys.config.system.build.toplevel; }) (filterSystemConfigs getSystemNixDarwin args.ciSystems attrs);
       formatter = forSystems (sys: formatter: formatter);
       templates = args: attrs: mapAttrs checkTemplate attrs;
 

--- a/tests/default-herculesCI-for-flake-test.nix
+++ b/tests/default-herculesCI-for-flake-test.nix
@@ -50,8 +50,13 @@ in rec {
   flake2 = toFlake {
     packages.x86_64-linux.hello = fakePkg "hello86";
     packages.aarch64-darwin.hello = fakePkg "iHello";
+    nixosConfigurations.rusty = lib.nixosSystem { modules = [ ]; system = "x86_64-linux"; };
+    nixosConfigurations.trusty = lib.nixosSystem { modules = [{ nixpkgs.hostPlatform = "x86_64-linux"; }]; };
+    nixosConfigurations.dusty = lib.nixosSystem { modules = [{ nixpkgs.hostPlatform = "i686-linux"; }]; };
+    darwinConfigurations.my-intel.config.system.build.toplevel = fakePkg "my-intel" // { stdenv.buildPlatform.system = "x86_64-darwin"; };
+    darwinConfigurations.my-apple.config.system.build.toplevel = fakePkg "my-apple" // { stdenv.buildPlatform.system = "aarch64-darwin"; };
     herculesCI = args: {
-      ciSystems = [ "x86_64-linux" ];
+      ciSystems = [ "x86_64-linux" "x86_64-darwin" ];
     };
   };
   outputs2 = addDefaults flake2 { herculesCI = { ciSystems = { "aarch64-darwin" = null; }; }; };
@@ -59,6 +64,8 @@ in rec {
   test = done:
     assert outputs1 == flakeOutputs1;
     assert lib.attrNames (outputs2.onPush.default.outputs.packages) == [ "x86_64-linux" ];
+    assert lib.attrNames (outputs2.onPush.default.outputs.nixosConfigurations) == [ "rusty" "trusty" ];
+    assert lib.attrNames (outputs2.onPush.default.outputs.darwinConfigurations) == [ "my-intel" ];
     done;
 
 }

--- a/tests/default-herculesCI-for-flake-test.nix
+++ b/tests/default-herculesCI-for-flake-test.nix
@@ -53,8 +53,10 @@ in rec {
     nixosConfigurations.rusty = lib.nixosSystem { modules = [ ]; system = "x86_64-linux"; };
     nixosConfigurations.trusty = lib.nixosSystem { modules = [{ nixpkgs.hostPlatform = "x86_64-linux"; }]; };
     nixosConfigurations.dusty = lib.nixosSystem { modules = [{ nixpkgs.hostPlatform = "i686-linux"; }]; };
-    darwinConfigurations.my-intel.config.system.build.toplevel = fakePkg "my-intel" // { stdenv.buildPlatform.system = "x86_64-darwin"; };
-    darwinConfigurations.my-apple.config.system.build.toplevel = fakePkg "my-apple" // { stdenv.buildPlatform.system = "aarch64-darwin"; };
+    darwinConfigurations.my-intel.config.system.build.toplevel = fakePkg "my-intel";
+    darwinConfigurations.my-intel.config.nixpkgs.system = "x86_64-darwin";
+    darwinConfigurations.my-apple.config.system.build.toplevel = fakePkg "my-apple";
+    darwinConfigurations.my-apple.config.nixpkgs.system = "aarch64-darwin";
     herculesCI = args: {
       ciSystems = [ "x86_64-linux" "x86_64-darwin" ];
     };


### PR DESCRIPTION
It has a different nixpkgs module. Didn't show up in testing because `ciSystems` wasn't set.