### PR TITLE
Allow setting Nix verbosity in config

### DIFF
--- a/docs/modules/ROOT/pages/agent-config.adoc
+++ b/docs/modules/ROOT/pages/agent-config.adoc
@@ -96,6 +96,11 @@ involving arrays of non-primitive types may not be representable currently.
 
 Optional. Defaults to `InfoS`. More verbose: `DebugS`, less verbose: `WarningS`, `ErrorS`.
 
+[[nixVerbosity]]
+== nixVerbosity
+
+Optional. Defaults to `Talkative`. More verbose: `Debug`, `Vomit`, less verbose: `Info`, `Warn`, `Error`.
+
 [[secretsJsonPath]]
 == secretsJsonPath
 

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent.hs
@@ -81,10 +81,10 @@ import qualified Prelude
 
 main :: IO ()
 main = do
-  Init.initCNix
   opts <- Options.parse
   let cfgPath = Options.configFile opts
   cfg <- Config.finalizeConfig cfgPath =<< Config.readConfig cfgPath
+  Init.initCNix cfg
   Init.setupLogging cfg $ \logEnv -> do
     env <- Init.newEnv cfg logEnv
     case Options.mode opts of

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config.hs
@@ -19,6 +19,7 @@ import qualified Data.Aeson.KeyMap as AK
 import Data.Scientific (floatingOrInteger, fromFloatDigits)
 import qualified Data.Vector as V
 import GHC.Conc (getNumProcessors)
+import Hercules.CNix.Verbosity (Verbosity (..))
 import Katip (Severity (..))
 import Protolude hiding (to)
 import qualified System.Environment
@@ -56,6 +57,7 @@ data Config purpose = Config
     binaryCachesPath :: Item purpose 'Required FilePath,
     secretsJsonPath :: Item purpose 'Required FilePath,
     logLevel :: Item purpose 'Required Severity,
+    nixVerbosity :: Item purpose 'Required Verbosity,
     labels :: Item purpose 'Required (Map Text A.Value),
     allowInsecureBuiltinFetchers :: Item purpose 'Required Bool
   }
@@ -89,6 +91,8 @@ tomlCodec =
     .= secretsJsonPath
     <*> dioptional (Toml.enumBounded "logLevel")
     .= logLevel
+    <*> dioptional (Toml.enumBounded "nixVerbosity")
+    .= nixVerbosity
     <*> dioptional (Toml.tableMap _KeyText embedJson "labels")
     .= labels
     <*> dioptional (Toml.bool "allowInsecureBuiltinFetchers")
@@ -214,6 +218,7 @@ finalizeConfig loc input = do
         secretsJsonPath = secretsJsonP,
         workDirectory = workDir,
         logLevel = logLevel input & fromMaybe InfoS,
+        nixVerbosity = nixVerbosity input & fromMaybe Talkative,
         labels = fromMaybe mempty $ labels input,
         allowInsecureBuiltinFetchers = fromMaybe False $ allowInsecureBuiltinFetchers input
       }

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Init.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Init.hs
@@ -13,6 +13,7 @@ import qualified Hercules.Agent.ServiceInfo as ServiceInfo
 import qualified Hercules.Agent.Token as Token
 import qualified Hercules.CNix
 import qualified Hercules.CNix.Util
+import qualified Hercules.CNix.Verbosity
 import qualified Katip as K
 import qualified Network.HTTP.Client.TLS
 import Protolude
@@ -65,8 +66,8 @@ setupLogging cfg f = do
 emptyNamespace :: K.Namespace
 emptyNamespace = K.Namespace []
 
-initCNix :: IO ()
-initCNix = do
+initCNix :: Config.FinalConfig -> IO ()
+initCNix cfg = do
   Hercules.CNix.init
-  Hercules.CNix.setTalkative
+  Hercules.CNix.Verbosity.setVerbosity $ Config.nixVerbosity cfg
   Hercules.CNix.Util.installDefaultSigINTHandler


### PR DESCRIPTION
This allows a developer to try and debug Nix configuration issues, by seeing more of the Nix output when running the agent.