### PR TITLE
hercules-ci-agent: Do not chdir the build worker

### DIFF
--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Build.hs
@@ -59,7 +59,7 @@ performBuild buildTask = do
         (System.Process.proc workerExe opts)
           { env = Just workerEnv,
             close_fds = True,
-            cwd = Just "/"
+            cwd = Nothing
           }
       writeEvent :: Event.Event -> App ()
       writeEvent event = case event of


### PR DESCRIPTION
It used to go to `/`, but that may fail on darwin:

    /nix/store/gq3lh1gg4k16bwj42phgxzi3as47v45i-hercules-ci-agent-0.9.11/bin/hercules-ci-agent-worker: createProcess: chdir: invalid argument (Bad file descriptor)

  -- https://hercules-ci.com/accounts/github/hercules-ci/derivations/%2Fnix%2Fstore%2Fim8z1s5g07qfkzz4f8blhd95wzrjgfnr-hercules-ci-cnix-expr-0.3.5.1.drv/log?via-job=3f8281d8-f0a7-4810-aee0-8a5a1f078bd8