### PR TITLE
Update haskell-flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1678745009,
-        "narHash": "sha256-ujfwSrkxThmHJozibkCnJmlXLVyxm+Cbo2Q4wXPbCS4=",
+        "lastModified": 1684780604,
+        "narHash": "sha256-2uMZsewmRn7rRtAnnQNw1lj0uZBMh4m6Cs/7dV5YF08=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "26852ade574c712bc3912ad28de52b0c4cf7d4cb",
+        "rev": "74210fa80a49f1b6f67223debdbf1494596ff9f2",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "0.2.0",
+        "ref": "0.3.0",
         "repo": "haskell-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
   inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-  inputs.haskell-flake.url = "github:srid/haskell-flake/0.2.0";
+  inputs.haskell-flake.url = "github:srid/haskell-flake/0.3.0";
 
   # Optional. Omit to use nixpkgs' nix
   # inputs.nix = {

--- a/flake.nix
+++ b/flake.nix
@@ -291,6 +291,9 @@
                   inherit system;
                 };
 
+              apps.hci = config.apps.internal-hci;
+              apps.hercules-ci-agent = config.apps.internal-hercules-ci-agent;
+
               haskellProjects = {
                 internal = {
 


### PR DESCRIPTION
Prevents unnecessary IFD rebuilds when building the hercules-ci-agent flake