### PR TITLE
OpenAPI 3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -294,6 +294,8 @@
 
                   overrides = self: super: {
 
+                    openapi3 = h.dontCheck (h.unmarkBroken super.openapi3);
+
                     cachix_saved = super.cachix;
 
                     cachix =

--- a/hercules-ci-api-core/hercules-ci-api-core.cabal
+++ b/hercules-ci-api-core/hercules-ci-api-core.cabal
@@ -47,7 +47,9 @@ library
     , memory
     , lifted-base
     , monad-control
+    , openapi3
     , servant >=0.14.1
+    , servant-openapi3
     , servant-auth
     , servant-auth-swagger
     , servant-swagger

--- a/hercules-ci-api-core/src/Hercules/API/DayOfWeek.hs
+++ b/hercules-ci-api-core/src/Hercules/API/DayOfWeek.hs
@@ -22,6 +22,7 @@ where
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Maybe (fromJust)
+import qualified Data.OpenApi as O3
 import Data.Swagger (ToSchema)
 import qualified Data.Time
 import GHC.Generics (Generic)
@@ -29,7 +30,7 @@ import Prelude (Eq, Integral, Maybe (..), Num (..), Show, mod)
 
 -- | Day of week representation used in the API.
 data DayOfWeek = Mon | Tue | Wed | Thu | Fri | Sat | Sun
-  deriving (Generic, Show, Eq, NFData, ToJSON, FromJSON, ToSchema)
+  deriving (Generic, Show, Eq, NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 -- | Conversion to @time@ package representation.
 toTime :: DayOfWeek -> Data.Time.DayOfWeek

--- a/hercules-ci-api-core/src/Hercules/API/Id.hs
+++ b/hercules-ci-api-core/src/Hercules/API/Id.hs
@@ -99,3 +99,9 @@ instance forall k (a :: k). (Typeable a, Typeable k) => O3.ToSchema (Id a) where
         mempty
           & O3.type_ ?~ O3.OpenApiString
           & O3.format ?~ "uuid"
+
+instance O3.ToParamSchema (Id a) where
+  toParamSchema _ =
+    mempty
+      & O3.type_ ?~ O3.OpenApiString
+      & O3.format ?~ "uuid"

--- a/hercules-ci-api-core/src/Hercules/API/Name.hs
+++ b/hercules-ci-api-core/src/Hercules/API/Name.hs
@@ -63,3 +63,6 @@ invmap _ _ = Proxy
 
 instance forall k (a :: k). (Typeable a, Typeable k) => O3.ToSchema (Name a) where
   declareNamedSchema = O3.declareNamedSchema . invmap nameText
+
+instance O3.ToParamSchema (Name a) where
+  toParamSchema = O3.toParamSchema . invmap nameText

--- a/hercules-ci-api-core/src/Hercules/API/Name.hs
+++ b/hercules-ci-api-core/src/Hercules/API/Name.hs
@@ -11,19 +11,21 @@ where
 import Control.DeepSeq (NFData)
 import Data.Aeson
 import Data.Hashable (Hashable (..))
+import qualified Data.OpenApi as O3
 import Data.Proxy
 import Data.Swagger
   ( ToParamSchema (..),
     ToSchema (..),
   )
 import Data.Text (Text)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Web.HttpApiData
 import Prelude
 
 -- | A slug. Display names are simply 'Text'.
 newtype Name (a :: k) = Name {nameText :: Text}
-  deriving (Generic, Eq, Ord)
+  deriving (Generic, Eq, Ord, Typeable)
   deriving newtype (NFData)
 
 instance Hashable (Name a)
@@ -56,3 +58,8 @@ instance ToParamSchema (Name a) where
 
 invmap :: (a -> b) -> proxy a -> Proxy b
 invmap _ _ = Proxy
+
+-- OpenAPI 3
+
+instance forall k (a :: k). (Typeable a, Typeable k) => O3.ToSchema (Name a) where
+  declareNamedSchema = O3.declareNamedSchema . invmap nameText

--- a/hercules-ci-api-core/src/Hercules/API/Prelude.hs
+++ b/hercules-ci-api-core/src/Hercules/API/Prelude.hs
@@ -14,6 +14,7 @@ module Hercules.API.Prelude
 
     -- * Type classes
     Generic,
+    Typeable,
     NFData (..),
     ToJSON,
     FromJSON,
@@ -39,6 +40,7 @@ import Data.Set (Set)
 import Data.Swagger (ToSchema)
 import Data.Text (Text)
 import Data.Time (UTCTime)
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Hercules.API.Id (Id)
 import Hercules.API.Name (Name)

--- a/hercules-ci-api/hercules-ci-api.cabal
+++ b/hercules-ci-api/hercules-ci-api.cabal
@@ -155,8 +155,10 @@ library
     , lens-aeson
     , memory
     , network-uri
+    , openapi3
     , profunctors
     , servant                  >=0.14.1
+    , servant-openapi3
     , servant-auth
     , servant-auth-swagger
     , servant-swagger
@@ -185,10 +187,12 @@ executable hercules-gen-swagger
     , lens
     , memory
     , network-uri
+    , openapi3
     , profunctors
     , servant                  >=0.14.1
     , servant-auth
     , servant-auth-swagger
+    , servant-openapi3
     , servant-swagger
     , servant-swagger-ui-core
     , string-conv

--- a/hercules-ci-api/hercules-gen-swagger/Main.hs
+++ b/hercules-ci-api/hercules-gen-swagger/Main.hs
@@ -7,12 +7,15 @@ import Data.Aeson (encode)
 import Data.String.Conv (toS)
 import Hercules.API (openapi3, swagger)
 import System.Environment (getArgs)
+import System.IO (hPutStrLn, stderr)
 import Prelude
 
 main :: IO ()
 main = do
   args <- getArgs
   case args of
-    ["--openapi3"] -> putStrLn $ toS $ encode openapi3
+    ["--experimental-openapi3"] -> putStrLn $ toS $ encode openapi3
     [] -> putStrLn $ toS $ encode swagger
-    _ -> error $ "Unknown arguments" <> show args
+    _ -> do
+      hPutStrLn stderr "Usage: hercules-gen-swagger [--experimental-openapi3] > swagger.json"
+      error $ "Unknown arguments" <> show args

--- a/hercules-ci-api/hercules-gen-swagger/Main.hs
+++ b/hercules-ci-api/hercules-gen-swagger/Main.hs
@@ -5,8 +5,14 @@ where
 
 import Data.Aeson (encode)
 import Data.String.Conv (toS)
-import Hercules.API (swagger)
+import Hercules.API (openapi3, swagger)
+import System.Environment (getArgs)
 import Prelude
 
 main :: IO ()
-main = putStrLn $ toS $ encode swagger
+main = do
+  args <- getArgs
+  case args of
+    ["--openapi3"] -> putStrLn $ toS $ encode openapi3
+    [] -> putStrLn $ toS $ encode swagger
+    _ -> error $ "Unknown arguments" <> show args

--- a/hercules-ci-api/src/Hercules/API.hs
+++ b/hercules-ci-api/src/Hercules/API.hs
@@ -8,7 +8,6 @@ module Hercules.API
     servantApi,
     servantClientApi,
     swagger,
-    openapi3,
     useApi,
     enterApiE,
     API,
@@ -26,6 +25,9 @@ module Hercules.API
 
     -- * Utilities
     noContent,
+
+    -- * Experimental
+    openapi3,
   )
 where
 
@@ -142,6 +144,7 @@ swagger =
 apiWithJWT :: Proxy (ClientServantAPI (Auth '[JWT] ()))
 apiWithJWT = servantClientApi @(Auth '[JWT] ())
 
+-- | NOTE: this has not been tested yet.
 openapi3 :: O3.OpenApi
 openapi3 = SO3.toOpenApi apiWithJWT
 

--- a/hercules-ci-api/src/Hercules/API/Accounts/Account.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/Account.hs
@@ -3,17 +3,18 @@
 
 module Hercules.API.Accounts.Account where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Forge.Forge (Forge)
 import Hercules.API.Organizations.Organization qualified as Organization
 import Hercules.API.Prelude
 
 data AccountType = User | Organization
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data MembershipRole = Member | Admin
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data Account = Account
   { id :: Id Account,
@@ -43,4 +44,4 @@ data Account = Account
     installationIsSelection :: Maybe Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/AccountInstallationStatus.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/AccountInstallationStatus.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.AccountInstallationStatus where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Forge.Forge (Forge)
 import Hercules.API.Prelude
@@ -14,4 +15,4 @@ data AccountInstallationStatus = AccountInstallationStatus
     secondsSinceInstallationWebHookComplete :: Maybe Int
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/AccountSettings.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/AccountSettings.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.AccountSettings where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data AccountSettings = AccountSettings
@@ -10,4 +11,4 @@ data AccountSettings = AccountSettings
     enableNewRepos :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/AccountSettingsPatch.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/AccountSettingsPatch.hs
@@ -3,10 +3,11 @@
 
 module Hercules.API.Accounts.AccountSettingsPatch where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data AccountSettingsPatch = AccountSettingsPatch
   { enableNewRepos :: Maybe Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequest.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequest.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.CLIAuthorizationRequest where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CLIAuthorizationRequest = CLIAuthorizationRequest
@@ -10,4 +11,4 @@ data CLIAuthorizationRequest = CLIAuthorizationRequest
     creationTime :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestCreate.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestCreate.hs
@@ -3,10 +3,11 @@
 
 module Hercules.API.Accounts.CLIAuthorizationRequestCreate where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CLIAuthorizationRequestCreate = CLIAuthorizationRequestCreate
   { description :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestCreateResponse.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestCreateResponse.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.CLIAuthorizationRequestCreateResponse where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CLIAuthorizationRequestCreateResponse = CLIAuthorizationRequestCreateResponse
@@ -10,4 +11,4 @@ data CLIAuthorizationRequestCreateResponse = CLIAuthorizationRequestCreateRespon
     browserURL :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestStatus.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLIAuthorizationRequestStatus.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.CLIAuthorizationRequestStatus where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CLIAuthorization = CLIAuthorization
@@ -10,14 +11,14 @@ data CLIAuthorization = CLIAuthorization
     userIdentities :: [Text]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data CLIAuthorizationStatus = Pending () | Granted CLIAuthorization
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data CLIAuthorizationRequestStatus = CLIAuthorizationRequestStatus
   { status :: CLIAuthorizationStatus
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLIToken.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLIToken.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Accounts.CLIToken where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 
@@ -14,4 +15,4 @@ data CLIToken = CLIToken
     userId :: Id Account
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/CLITokensResponse.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/CLITokensResponse.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.CLITokensResponse where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.CLIToken (CLIToken)
 import Hercules.API.Prelude
 
@@ -10,4 +11,4 @@ data CLITokensResponse = CLITokensResponse
   { cliTokens :: [CLIToken]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/NotificationSettings.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/NotificationSettings.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Accounts.NotificationSettings where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Forge.SimpleForge (SimpleForge)
 import Hercules.API.Prelude
@@ -12,21 +13,21 @@ data NotificationLevel
   = Ignore
   | All
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data NotificationSetting = NotificationSetting
   { notificationLevel :: Maybe NotificationLevel,
     notificationEmail :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data NotificationAccountOverride = NotificationSettingsOverride
   { account :: SimpleAccount,
     setting :: NotificationSetting
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data AuthorizedEmail = AuthorizedEmail
   { address :: Text,
@@ -34,7 +35,7 @@ data AuthorizedEmail = AuthorizedEmail
     source :: Maybe SimpleForge
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data NotificationSettings = NotificationSettings
   { authorizedEmails :: [AuthorizedEmail],
@@ -42,4 +43,4 @@ data NotificationSettings = NotificationSettings
     accountOverrides :: [NotificationAccountOverride]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/NotificationSettingsPatch.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/NotificationSettingsPatch.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.NotificationSettingsPatch where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Accounts.NotificationSettings (NotificationSetting)
 import Hercules.API.Prelude
@@ -12,4 +13,4 @@ data NotificationSettingsPatch = NotificationSettingsPatch
     accountOverrides :: Map (Id Account) NotificationSetting
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Accounts/SimpleAccount.hs
+++ b/hercules-ci-api/src/Hercules/API/Accounts/SimpleAccount.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Accounts.SimpleAccount where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account, AccountType)
 import Hercules.API.Forge.SimpleForge (SimpleForge)
 import Hercules.API.Prelude
@@ -16,4 +17,4 @@ data SimpleAccount = SimpleAccount
     site :: SimpleForge
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Agents/AgentSession.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/AgentSession.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Agents.AgentSession where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Agents.ClusterJoinToken
   ( ClusterJoinToken,
   )
@@ -29,4 +30,4 @@ data AgentSession = AgentSession
     labels :: Labels
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Agents/ClusterJoinToken.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/ClusterJoinToken.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Agents.ClusterJoinToken where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 
@@ -14,4 +15,4 @@ data ClusterJoinToken = ClusterJoinToken
     description :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Agents/CreateClusterJoinToken.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/CreateClusterJoinToken.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Agents.CreateClusterJoinToken where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 -- The owner account that the token applies to is in the path.
@@ -10,4 +11,4 @@ data CreateClusterJoinToken = CreateClusterJoinToken
   { description :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Agents/FullClusterJoinToken.hs
+++ b/hercules-ci-api/src/Hercules/API/Agents/FullClusterJoinToken.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Agents.FullClusterJoinToken where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Agents.ClusterJoinToken
   ( ClusterJoinToken,
   )
@@ -13,4 +14,4 @@ data FullClusterJoinToken = FullClusterJoinToken
     token :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Attribute.hs
+++ b/hercules-ci-api/src/Hercules/API/Attribute.hs
@@ -16,6 +16,7 @@ import Control.Lens (at, (%~))
 import Data.Aeson qualified as A
 import Data.Aeson.Lens
 import Data.Function ((&))
+import Data.OpenApi qualified as O3
 import Data.Proxy (Proxy (Proxy))
 import Data.Swagger (ToParamSchema (..))
 import Data.Text qualified as T
@@ -30,7 +31,7 @@ data AttributeType
   | DependenciesOnly
   | Effect
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 -- | An arbitrary ordering
 deriving instance Ord AttributeType

--- a/hercules-ci-api/src/Hercules/API/Attribute.hs
+++ b/hercules-ci-api/src/Hercules/API/Attribute.hs
@@ -52,6 +52,8 @@ instance (FromJSON a) => FromJSON (Attribute a) where
 
 deriving instance (ToSchema a) => ToSchema (Attribute a)
 
+deriving instance (O3.ToSchema a) => O3.ToSchema (Attribute a)
+
 deriving instance Functor Attribute
 
 deriving instance Foldable Attribute
@@ -72,6 +74,9 @@ instance ToParamSchema AttributePath where
 
 instance ToHttpApiData AttributePath where
   toUrlPiece = toUrlPiece . attributePathToString . fromAttributePath
+
+instance O3.ToParamSchema AttributePath where
+  toParamSchema _ = O3.toParamSchema (Proxy :: Proxy Text)
 
 ----------------------------------------
 

--- a/hercules-ci-api/src/Hercules/API/BillingStatus.hs
+++ b/hercules-ci-api/src/Hercules/API/BillingStatus.hs
@@ -8,6 +8,7 @@ module Hercules.API.BillingStatus
   )
 where
 
+import Data.OpenApi qualified as O3
 import Data.Swagger
 import Hercules.API.Prelude
 
@@ -19,7 +20,7 @@ data BillingStatus
   | External
   | Enterprise
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 toText :: BillingStatus -> Text
 toText Community = "Community"

--- a/hercules-ci-api/src/Hercules/API/Build/AgentRequirements.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/AgentRequirements.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.AgentRequirements where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data AgentRequirements = AgentRequirements
@@ -10,4 +11,4 @@ data AgentRequirements = AgentRequirements
     requiredSystemFeatures :: [Text]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationEvent.hs
@@ -6,6 +6,7 @@
 module Hercules.API.Build.DerivationEvent where
 
 import Data.Aeson.Types (FromJSON (..), ToJSON (..), genericParseJSON, genericToEncoding, genericToJSON)
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Build.DerivationEvent.BuiltOutput
 import Hercules.API.Prelude
@@ -52,13 +53,13 @@ data DerivationEventQueued = DerivationEventQueued
     requeuedForAgent :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventDependencyFailed = DerivationEventDependencyFailed
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventStarted = DerivationEventStarted
   { time :: UTCTime,
@@ -67,55 +68,55 @@ data DerivationEventStarted = DerivationEventStarted
     streamable :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventReset = DerivationEventReset
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventFailed = DerivationEventFailed
   { time :: UTCTime,
     technicalError :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventSucceeded = DerivationEventSucceeded
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventCancelled = DerivationEventCancelled
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventForceCancelled = DerivationEventForceCancelled
   { time :: UTCTime,
     byUser :: Maybe SimpleAccount
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventBuilt = DerivationEventBuilt
   { time :: UTCTime,
     outputs :: [BuiltOutput]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventHasCancelledForReset = DerivationEventHasCancelledForReset
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationEventHasCancelled = DerivationEventHasCancelled
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationEvent.hs
@@ -24,7 +24,7 @@ data DerivationEvent
   | Built DerivationEventBuilt
   | HasCancelled DerivationEventHasCancelled
   | HasCancelledForReset DerivationEventHasCancelledForReset
-  deriving (Generic, Show, Eq, NFData, ToSchema)
+  deriving (Generic, Show, Eq, NFData, ToSchema, O3.ToSchema)
 
 instance FromJSON DerivationEvent where
   parseJSON = genericParseJSON schemaCompatibleOptions

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationEvent/BuiltOutput.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationEvent/BuiltOutput.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.DerivationEvent.BuiltOutput where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data BuiltOutput = BuiltOutput
@@ -12,4 +13,4 @@ data BuiltOutput = BuiltOutput
     size :: Int64
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationInfo.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationInfo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.DerivationInfo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Build.DerivationEvent (DerivationEvent)
 import Hercules.API.Build.DerivationInfo.DerivationInput (DerivationInput)
 import Hercules.API.Build.DerivationInfo.DerivationOutput (DerivationOutput)
@@ -26,4 +27,4 @@ data DerivationInfo = DerivationInfo
     dummy :: Maybe DerivationEvent -- TODO: remove and update/fix codegen
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationInfo/DerivationInput.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationInfo/DerivationInput.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.DerivationInfo.DerivationInput where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Derivation (DerivationStatus)
 import Hercules.API.Prelude
 
@@ -13,4 +14,4 @@ data DerivationInput = DerivationInput
     outputPath :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/DerivationInfo/DerivationOutput.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/DerivationInfo/DerivationOutput.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.DerivationInfo.DerivationOutput where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data DerivationOutput = DerivationOutput
@@ -10,4 +11,4 @@ data DerivationOutput = DerivationOutput
     outputPath :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/EvaluationDependency.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/EvaluationDependency.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.EvaluationDependency where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Derivation (Derivation)
 import Hercules.API.Prelude
 
@@ -12,4 +13,4 @@ data EvaluationDependency = EvaluationDependency
     outputName :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/EvaluationDetail.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/EvaluationDetail.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Build.EvaluationDetail where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Attribute (Attribute)
 import Hercules.API.Build.AgentRequirements (AgentRequirements)
 import Hercules.API.Build.EvaluationDependency
@@ -40,8 +41,8 @@ data EvaluationDetail = EvaluationDetail
     unmetAgentRequirements :: [AgentRequirements]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 newtype IFDAttribute = IFDAttribute (Attribute Derivation)
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/EvaluationDiff.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/EvaluationDiff.hs
@@ -11,6 +11,7 @@ module Hercules.API.Build.EvaluationDiff
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Attribute (Attribute)
 import Hercules.API.Derivation (Derivation)
 import Hercules.API.Evaluation.AttributeError (AttributeError)
@@ -36,22 +37,22 @@ deriving instance (ToSchema a) => ToSchema (Diff a)
 
 newtype AttributeDiff = AttributeDiff (SimpleAttribute AttributeValueDiff)
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 newtype AttributeValueDiff = AttributeValueDiff (Diff (Attribute (Result AttributeError Derivation)))
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 newtype IFDDiff = IFDDiff (Diff DerivationOutputNamePair)
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationOutputNamePair = DerivationOutputNamePair
   { derivation :: Derivation,
     outputName :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EvaluationDiff = EvaluationDiff
   { beforeId :: Id Evaluation,
@@ -60,4 +61,4 @@ data EvaluationDiff = EvaluationDiff
     ifds :: [IFDDiff]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/EvaluationDiff.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/EvaluationDiff.hs
@@ -35,6 +35,8 @@ data Diff a = Diff {before :: Maybe a, after :: Maybe a}
 
 deriving instance (ToSchema a) => ToSchema (Diff a)
 
+deriving instance (O3.ToSchema a) => O3.ToSchema (Diff a)
+
 newtype AttributeDiff = AttributeDiff (SimpleAttribute AttributeValueDiff)
   deriving (Generic, Show, Eq)
   deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/FailureGraph.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/FailureGraph.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Build.FailureGraph where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Derivation (Derivation)
 import Hercules.API.Prelude
 
@@ -13,7 +14,7 @@ data Graph = Graph
   { nodes :: [Node]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 -- | A derivation and any dependencies that caused it to fail, if applicable.
 data Node = Node
@@ -23,4 +24,4 @@ data Node = Node
     failedDependencies :: [Text]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/Log.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/Log.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Build.Log where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Build.LogLine
 import Hercules.API.Prelude
 
@@ -13,4 +14,4 @@ data Log = Log
     done :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Build/LogLine.hs
+++ b/hercules-ci-api/src/Hercules/API/Build/LogLine.hs
@@ -3,9 +3,10 @@
 
 module Hercules.API.Build.LogLine where
 
+import Data.OpenApi qualified as O3
 import Data.Word
 import Hercules.API.Prelude
 
 data LogLine = LogLine {i :: !Word64, ms :: !Word64, t :: !Text}
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/ClientInfo/ClientInfo.hs
+++ b/hercules-ci-api/src/Hercules/API/ClientInfo/ClientInfo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.ClientInfo.ClientInfo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Forge.Forge (Forge)
 import Hercules.API.Prelude
@@ -16,4 +17,4 @@ data ClientInfo = ClientInfo
     personalAccounts :: [Account]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Derivation.hs
+++ b/hercules-ci-api/src/Hercules/API/Derivation.hs
@@ -3,20 +3,21 @@
 
 module Hercules.API.Derivation where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude hiding (either)
 
 data DerivationPath = DerivationPath
   { drvPath :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data Derivation = Derivation
   { status :: DerivationStatus,
     derivationPath :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data DerivationStatus
   = Waiting
@@ -26,4 +27,4 @@ data DerivationStatus
   | BuildSuccess
   | Cancelled
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Effects/EffectEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Effects/EffectEvent.hs
@@ -16,7 +16,7 @@ data EffectEvent
   | Failed EffectEventFailed
   | Succeeded EffectEventSucceeded
   | Cancelled EffectEventCancelled
-  deriving (Generic, Show, Eq, NFData, ToSchema)
+  deriving (Generic, Show, Eq, NFData, ToSchema, O3.ToSchema)
 
 instance FromJSON EffectEvent where
   parseJSON = genericParseJSON schemaCompatibleOptions

--- a/hercules-ci-api/src/Hercules/API/Effects/EffectEvent.hs
+++ b/hercules-ci-api/src/Hercules/API/Effects/EffectEvent.hs
@@ -6,6 +6,7 @@
 module Hercules.API.Effects.EffectEvent where
 
 import Data.Aeson.Types (FromJSON (..), ToJSON (..), genericParseJSON, genericToEncoding, genericToJSON)
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data EffectEvent
@@ -37,13 +38,13 @@ data EffectEventQueued = EffectEventQueued
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventDependencyFailed = EffectEventDependencyFailed
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventStarted = EffectEventStarted
   { time :: UTCTime,
@@ -52,29 +53,29 @@ data EffectEventStarted = EffectEventStarted
     agentVersion :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventReset = EffectEventReset
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventFailed = EffectEventFailed
   { time :: UTCTime,
     technicalError :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventSucceeded = EffectEventSucceeded
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectEventCancelled = EffectEventCancelled
   { time :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Effects/EffectInfo.hs
+++ b/hercules-ci-api/src/Hercules/API/Effects/EffectInfo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Effects.EffectInfo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Build.DerivationInfo.DerivationInput (DerivationInput)
 import Hercules.API.Effects.EffectEvent (EffectEvent)
 import Hercules.API.Effects.EffectReference (EffectReference)
@@ -19,7 +20,7 @@ data EffectStatus
   | Successful
   | Cancelled
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data EffectInfo = EffectInfo
   { status :: EffectStatus,
@@ -35,4 +36,4 @@ data EffectInfo = EffectInfo
     dummy :: Maybe EffectEvent -- TODO: remove and update/fix codegen
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Effects/EffectReference.hs
+++ b/hercules-ci-api/src/Hercules/API/Effects/EffectReference.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Effects.EffectReference where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.SimpleJob (SimpleJob)
 
@@ -11,4 +12,4 @@ data EffectReference = EffectReference
     attributePath :: [Text]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Error.hs
+++ b/hercules-ci-api/src/Hercules/API/Error.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Error where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 -- | General error type used in (some) HTTP error response bodies and in some
@@ -15,4 +16,4 @@ data Error = Error
     message :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Evaluation/AttributeError.hs
+++ b/hercules-ci-api/src/Hercules/API/Evaluation/AttributeError.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Evaluation.AttributeError where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data AttributeError = AttributeError
@@ -14,4 +15,4 @@ data AttributeError = AttributeError
     trace :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Evaluation/Evaluation.hs
+++ b/hercules-ci-api/src/Hercules/API/Evaluation/Evaluation.hs
@@ -3,10 +3,11 @@
 
 module Hercules.API.Evaluation.Evaluation where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data Evaluation = Evaluation
   { id :: Id Evaluation
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Forge/Forge.hs
+++ b/hercules-ci-api/src/Hercules/API/Forge/Forge.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Forge.Forge where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 -- | A source hosting site (example github for github.com) used for
@@ -17,4 +18,4 @@ data Forge = Forge
     adminPermission :: Maybe Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Forge/SimpleForge.hs
+++ b/hercules-ci-api/src/Hercules/API/Forge/SimpleForge.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Forge.SimpleForge where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Forge.Forge (Forge)
 import Hercules.API.Prelude
 
@@ -12,4 +13,4 @@ data SimpleForge = SimpleForge
     displayName :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/GitLab/CreateInstallationBuilderRequest.hs
+++ b/hercules-ci-api/src/Hercules/API/GitLab/CreateInstallationBuilderRequest.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.GitLab.CreateInstallationBuilderRequest where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CreateInstallationBuilderRequest = CreateInstallationBuilderRequest
@@ -11,4 +12,4 @@ data CreateInstallationBuilderRequest = CreateInstallationBuilderRequest
     gitlabAdminPassword :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/GitLab/InstallationBuilder.hs
+++ b/hercules-ci-api/src/Hercules/API/GitLab/InstallationBuilder.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.GitLab.InstallationBuilder where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Error (Error)
 import Hercules.API.Forge.SimpleForge (SimpleForge)
 import Hercules.API.Prelude
@@ -16,10 +17,10 @@ data InstallationBuilder = InstallationBuilder
     errors :: [Error]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data InstallationBuilders = InstallationBuilders
   { items :: [InstallationBuilder]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/GitLab/PatchInstallationBuilder.hs
+++ b/hercules-ci-api/src/Hercules/API/GitLab/PatchInstallationBuilder.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.GitLab.PatchInstallationBuilder where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data PatchInstallationBuilder = PatchInstallationBuilder
@@ -10,4 +11,4 @@ data PatchInstallationBuilder = PatchInstallationBuilder
     displayName :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Inputs/ImmutableGitInput.hs
+++ b/hercules-ci-api/src/Hercules/API/Inputs/ImmutableGitInput.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Inputs.ImmutableGitInput where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.SimpleJob (SimpleJob)
 import Hercules.API.Repos.SimpleRepo (SimpleRepo)
@@ -17,4 +18,4 @@ data ImmutableGitInput = ImmutableGitInput
     historyURL :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Inputs/ImmutableInput.hs
+++ b/hercules-ci-api/src/Hercules/API/Inputs/ImmutableInput.hs
@@ -9,13 +9,14 @@ import Data.Aeson
     genericToEncoding,
     genericToJSON,
   )
+import Data.OpenApi qualified as O3
 import Hercules.API.Inputs.ImmutableGitInput
 import Hercules.API.Prelude
 
 data ImmutableInput
   = GitInput ImmutableGitInput
   | IgnoreMe ()
-  deriving (Generic, Show, Eq, NFData, ToSchema)
+  deriving (Generic, Show, Eq, NFData, ToSchema, O3.ToSchema)
 
 instance FromJSON ImmutableInput where
   parseJSON = genericParseJSON schemaCompatibleOptions

--- a/hercules-ci-api/src/Hercules/API/Labels.hs
+++ b/hercules-ci-api/src/Hercules/API/Labels.hs
@@ -6,6 +6,7 @@ module Hercules.API.Labels where
 import Control.Lens ((?~))
 import Data.Aeson (Value)
 import Data.Function ((&))
+import Data.OpenApi qualified as O3
 import Data.Swagger
 import Hercules.API.Prelude
 
@@ -19,3 +20,11 @@ instance ToSchema Labels where
       $ mempty
       & type_ ?~ SwaggerObject
       & additionalProperties ?~ AdditionalPropertiesAllowed True
+
+instance O3.ToSchema Labels where
+  declareNamedSchema _p = do
+    return
+      $ O3.NamedSchema (Just "Labels")
+      $ mempty
+      & O3.type_ ?~ O3.OpenApiObject
+      & O3.additionalProperties ?~ O3.AdditionalPropertiesAllowed True

--- a/hercules-ci-api/src/Hercules/API/Message.hs
+++ b/hercules-ci-api/src/Hercules/API/Message.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Message where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data Message = Message
@@ -11,7 +12,7 @@ data Message = Message
     message :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data Type
   = -- | Something went wrong, inform user about possible
@@ -27,4 +28,4 @@ data Type
     -- abstraction.
     Trace
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Organizations/BillingInfo.hs
+++ b/hercules-ci-api/src/Hercules/API/Organizations/BillingInfo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Organizations.BillingInfo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 
@@ -11,4 +12,4 @@ data BillingInfo = BillingInfo
     activeUsers :: [Account]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Organizations/CreateOrganization.hs
+++ b/hercules-ci-api/src/Hercules/API/Organizations/CreateOrganization.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Organizations.CreateOrganization where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 
@@ -11,4 +12,4 @@ data CreateOrganization = CreateOrganization
     primaryAccountId :: Id Account
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Organizations/Organization.hs
+++ b/hercules-ci-api/src/Hercules/API/Organizations/Organization.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Organizations.Organization where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.BillingStatus qualified as BillingStatus
 import Hercules.API.Prelude
 
@@ -17,4 +18,4 @@ data Organization = Organization
     subscriptionUpdateUrl :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Organizations/PaymentLink.hs
+++ b/hercules-ci-api/src/Hercules/API/Organizations/PaymentLink.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Organizations.PaymentLink where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data PaymentLink = PaymentLink
@@ -10,4 +11,4 @@ data PaymentLink = PaymentLink
     productId :: Integer
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Orphans.hs
+++ b/hercules-ci-api/src/Hercules/API/Orphans.hs
@@ -1,15 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Hercules.API.Orphans where
 
+import Control.Lens.Operators ((<>~))
+import Data.Data (Typeable)
+import Data.Function ((&), (.))
+import Data.Maybe (Maybe (Just))
+import Data.OpenApi qualified as O3
 import Data.Proxy
 import Data.Swagger
 import Servant.API
+import Servant.Auth (Auth, JWT)
+import Servant.OpenApi qualified as SO3
 
 -- | Ignores Headers.
 --
 -- FIXME: don't ignore headers
 instance forall a hs. (ToSchema a) => ToSchema (Headers hs a) where
   declareNamedSchema _ = declareNamedSchema (Proxy @a)
+
+-- | Ignores Headers.
+--
+-- FIXME: don't ignore headers
+instance forall a hs. (O3.ToSchema a, Typeable hs) => O3.ToSchema (Headers hs a) where
+  declareNamedSchema _ = O3.declareNamedSchema (Proxy @a)
+
+instance (SO3.HasOpenApi a) => SO3.HasOpenApi (Auth '[JWT] x :> a) where
+  toOpenApi _ =
+    SO3.toOpenApi (Proxy :: Proxy a)
+      & O3.security
+        <>~ [ O3.SecurityRequirement [("jwt", [])]
+            ]
+      & O3.components . O3.securitySchemes
+        <>~ O3.SecurityDefinitions
+          [ ( "jwt",
+              O3.SecurityScheme
+                (O3.SecuritySchemeHttp (O3.HttpSchemeBearer (Just "jwt")))
+                (Just "JSON Web Token authentication")
+            )
+          ]

--- a/hercules-ci-api/src/Hercules/API/Paging.hs
+++ b/hercules-ci-api/src/Hercules/API/Paging.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Paging where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 -- To be used in newtypes only; otherwise the schema will have colliding
@@ -16,3 +17,5 @@ data PagedResponse a = PagedResponse
   deriving (Generic, Show, Eq, NFData, ToJSON, FromJSON)
 
 deriving instance (ToSchema a) => ToSchema (PagedResponse a)
+
+deriving instance (O3.ToSchema a) => O3.ToSchema (PagedResponse a)

--- a/hercules-ci-api/src/Hercules/API/Projects.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Projects where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Build.EvaluationDetail
   ( EvaluationDetail,
@@ -246,4 +247,4 @@ data ProjectsAPI auth f = ProjectsAPI
 
 newtype PagedJobs = PagedJobs (PagedResponse Job)
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/CreateProject.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/CreateProject.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Projects.CreateProject where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Repos.Repo (Repo)
 
@@ -11,4 +12,4 @@ data CreateProject = CreateProject
     enabled :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/CreateUserEffectTokenResponse.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/CreateUserEffectTokenResponse.hs
@@ -3,10 +3,11 @@
 
 module Hercules.API.Projects.CreateUserEffectTokenResponse where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data CreateUserEffectTokenResponse = CreateUserEffectTokenResponse
   { token :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/Job.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/Job.hs
@@ -8,6 +8,7 @@ module Hercules.API.Projects.Job
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Evaluation.Evaluation
   ( Evaluation,
@@ -49,7 +50,7 @@ data Job = Job
     mayRerun :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data JobType
   = Config
@@ -57,7 +58,7 @@ data JobType
   | OnPush
   | OnSchedule
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data GitCommitSource = GitCommitSource
   { revision :: Text,
@@ -68,11 +69,11 @@ data GitCommitSource = GitCommitSource
     link :: Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data ProjectAndJobs = ProjectAndJobs
   { project :: Project,
     jobs :: [Job]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/JobHandlers.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/JobHandlers.hs
@@ -6,6 +6,7 @@ module Hercules.API.Projects.JobHandlers
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.Job (Job)
 import Hercules.API.Projects.JobHandlers.OnPushHandler (OnPushHandler)
@@ -17,4 +18,4 @@ data JobHandlers = JobHandlers
     onSchedule :: Map Text OnScheduleHandler
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/JobHandlers/OnPushHandler.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/JobHandlers/OnPushHandler.hs
@@ -6,6 +6,7 @@ module Hercules.API.Projects.JobHandlers.OnPushHandler
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data OnPushHandler = OnPushHandler
@@ -13,4 +14,4 @@ data OnPushHandler = OnPushHandler
     isFlake :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/JobHandlers/OnScheduleHandler.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/JobHandlers/OnScheduleHandler.hs
@@ -7,6 +7,7 @@ module Hercules.API.Projects.JobHandlers.OnScheduleHandler
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.DayOfWeek (DayOfWeek)
 import Hercules.API.Prelude
 
@@ -17,7 +18,7 @@ data OnScheduleHandler = OnScheduleHandler
     mainExists :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data TimeConstraints = TimeConstraints
   { minute :: Int,
@@ -26,4 +27,4 @@ data TimeConstraints = TimeConstraints
     dayOfMonth :: Maybe [Int]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/LegacySimpleJob.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/LegacySimpleJob.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Projects.LegacySimpleJob where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.Project (Project)
 import Hercules.API.Projects.SimpleJob (JobPhase, JobStatus)
@@ -17,4 +18,4 @@ data LegacySimpleJob = LegacySimpleJob
     phase :: JobPhase
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/PatchProject.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/PatchProject.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Projects.PatchProject where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 -- | Changes to a Project. 'Nothing' represents no change in a field.
@@ -10,4 +11,4 @@ data PatchProject = PatchProject
   { enabled :: Maybe Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/Project.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/Project.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Projects.Project where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Forge.Forge (Forge)
@@ -27,4 +28,4 @@ data Project = Project
     isPublic :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Projects/SimpleJob.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/SimpleJob.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Projects.SimpleJob where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.SimpleProject (SimpleProject)
 
@@ -15,7 +16,7 @@ data SimpleJob = SimpleJob
     phase :: JobPhase
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data JobPhase
   = Queued
@@ -24,14 +25,14 @@ data JobPhase
   | Effects
   | Done
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data JobStatus
   = Pending
   | Failure
   | Success
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 -- | Whichever is "worse": 'Failure' wins out, otherwise 'Pending' wins out, otherwise all are 'Success'.
 instance Semigroup JobStatus where

--- a/hercules-ci-api/src/Hercules/API/Projects/SimpleProject.hs
+++ b/hercules-ci-api/src/Hercules/API/Projects/SimpleProject.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.Projects.SimpleProject where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Prelude
 import Hercules.API.Projects.Project (Project)
@@ -20,4 +21,4 @@ data SimpleProject = SimpleProject
     isPublic :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Repos/Repo.hs
+++ b/hercules-ci-api/src/Hercules/API/Repos/Repo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Repos.Repo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 
@@ -28,4 +29,4 @@ data Repo = Repo
     isInstallable :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Repos/RepoKey.hs
+++ b/hercules-ci-api/src/Hercules/API/Repos/RepoKey.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Repos.RepoKey where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.Project (Project)
 
@@ -13,4 +14,4 @@ data RepoKey = RepoKey
     projectId :: Maybe (Id Project)
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Repos/SimpleRepo.hs
+++ b/hercules-ci-api/src/Hercules/API/Repos/SimpleRepo.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.Repos.SimpleRepo where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Prelude
 import Hercules.API.Repos.Repo (Repo)
@@ -16,4 +17,4 @@ data SimpleRepo = SimpleRepo
     isPublic :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/Result.hs
+++ b/hercules-ci-api/src/Hercules/API/Result.hs
@@ -16,6 +16,7 @@ import Data.Aeson
     genericToEncoding,
     genericToJSON,
   )
+import Data.OpenApi qualified as O3
 import Data.Profunctor
   ( Profunctor,
     dimap,
@@ -29,6 +30,8 @@ data Result e a
   deriving (Generic, Show, Read, Eq, Ord, NFData, Functor, Foldable, Traversable)
 
 deriving instance (ToSchema e, ToSchema a) => ToSchema (Result e a)
+
+deriving instance (O3.ToSchema e, O3.ToSchema a) => O3.ToSchema (Result e a)
 
 -- many more typeclasses can be implemented
 instance (FromJSON e, FromJSON a) => FromJSON (Result e a) where

--- a/hercules-ci-api/src/Hercules/API/SimpleAttribute.hs
+++ b/hercules-ci-api/src/Hercules/API/SimpleAttribute.hs
@@ -7,6 +7,7 @@ module Hercules.API.SimpleAttribute
   )
 where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Prelude ()
 
@@ -19,6 +20,8 @@ data SimpleAttribute a = SimpleAttribute
   deriving anyclass (NFData, FromJSON, ToJSON)
 
 deriving instance (ToSchema a) => ToSchema (SimpleAttribute a)
+
+deriving instance (O3.ToSchema a) => O3.ToSchema (SimpleAttribute a)
 
 deriving instance Functor SimpleAttribute
 

--- a/hercules-ci-api/src/Hercules/API/State.hs
+++ b/hercules-ci-api/src/Hercules/API/State.hs
@@ -5,6 +5,7 @@
 module Hercules.API.State where
 
 import Data.ByteString (ByteString)
+import Data.OpenApi qualified as O3
 import Data.Swagger (NamedSchema (NamedSchema), binarySchema)
 import Data.Swagger.Schema (ToSchema (..))
 import Hercules.API.Accounts.Account (Account)
@@ -23,6 +24,9 @@ newtype RawBytes = RawBytes {fromRawBytes :: ByteString}
 
 instance ToSchema RawBytes where
   declareNamedSchema _ = pure $ NamedSchema (Just "RawBytes") binarySchema
+
+instance O3.ToSchema RawBytes where
+  declareNamedSchema _ = pure $ O3.NamedSchema (Just "RawBytes") O3.binarySchema
 
 type ContentLength = Header "Content-Length" Integer
 

--- a/hercules-ci-api/src/Hercules/API/State/ProjectState.hs
+++ b/hercules-ci-api/src/Hercules/API/State/ProjectState.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.State.ProjectState where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.Project (Project)
 import Hercules.API.State.StateFile (StateFile)
@@ -12,4 +13,4 @@ data ProjectState = ProjectState
     stateFiles :: Map Text StateFile
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateFile.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateFile.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.State.StateFile where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.Projects.Project (Project)
 import Hercules.API.State.StateVersion (StateVersion)
@@ -13,4 +14,4 @@ data StateFile = StateFile
     versions :: [StateVersion]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateLockAcquireRequest.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateLockAcquireRequest.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.State.StateLockAcquireRequest where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data StateLockAcquireRequest = StateLockAcquireRequest
@@ -19,4 +20,4 @@ data StateLockAcquireRequest = StateLockAcquireRequest
     idempotencyKey :: Maybe (Id "IdempotencyKey")
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateLockAcquireResponse.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateLockAcquireResponse.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.State.StateLockAcquireResponse where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 import Hercules.API.State.StateLockLease (StateLockLease)
 
@@ -11,17 +12,17 @@ data StateLockAcquireResponse
   = Acquired StateLockAcquiredResponse
   | Blocked StateLockBlockedResponse
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data StateLockAcquiredResponse = StateLockAcquiredResponse
   { leaseId :: Id "StateLockLease",
     expirationTime :: UTCTime
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)
 
 data StateLockBlockedResponse = LockBlockedResponse
   { blockedByLeases :: [StateLockLease]
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateLockLease.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateLockLease.hs
@@ -4,6 +4,7 @@
 
 module Hercules.API.State.StateLockLease where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.SimpleAccount (SimpleAccount)
 import Hercules.API.Prelude
 import Hercules.API.Projects.SimpleJob (SimpleJob)
@@ -27,4 +28,4 @@ data StateLockLease = StateLockLease
     exclusive :: Bool
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateLockUpdateRequest.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateLockUpdateRequest.hs
@@ -4,10 +4,11 @@
 
 module Hercules.API.State.StateLockUpdateRequest where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Prelude
 
 data StateLockUpdateRequest = StateLockUpdateRequest
   { description :: Maybe Text
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/hercules-ci-api/src/Hercules/API/State/StateVersion.hs
+++ b/hercules-ci-api/src/Hercules/API/State/StateVersion.hs
@@ -3,6 +3,7 @@
 
 module Hercules.API.State.StateVersion where
 
+import Data.OpenApi qualified as O3
 import Hercules.API.Accounts.Account (Account)
 import Hercules.API.Prelude
 import Hercules.API.Projects.Job (Job)
@@ -22,4 +23,4 @@ data StateVersion = StateVersion
     size :: Maybe Int
   }
   deriving (Generic, Show, Eq)
-  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema)
+  deriving anyclass (NFData, ToJSON, FromJSON, ToSchema, O3.ToSchema)

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,9 @@ extra-deps:
   - ascii-progress-0.3.3.0@sha256:bdcdfabdd2f3e8de0cec4ea058810a77dd8b79506fc0cf90efb93ee9f99ff8e3,4168
   - concurrent-output-1.10.17@sha256:5b5d8d384dda22283b49c9ed35ca4f02a96f5cfed12b28160a341708d1177bf3,1678
   - terminal-size-0.3.4@sha256:f0318c54273d04afb65109683b442792dcb67af1ad01ab5ec64423a28bb97715,1291
+  - openapi3-3.2.4@sha256:d3d63e66b1dd9fa0cfffbc271a53a7d8e1647dea14f1f228bde3776740693322,4941
+  - servant-openapi3-2.0.1.6@sha256:bd35a4d7c9d6c1d01763ab65461978a0c1212d6070c72f4cf745b78918145d0f,4939
+  - cabal-doctest-1.0.9@sha256:6dea0dbd1457f43d96ce1cfb1bab8b9f55d4fb82940e2bfa5aad78e6e2260656,1517
 
 flags:
   hercules-ci-cnix-store:


### PR DESCRIPTION
Adds OpenAPI 3 schema in parallel to existing Swagger 2 schema, as backend codegen currently relies on that.

- [ ] See if it works
  - Figure out Swagger UI
- [ ] Check sum type representation
- [ ] Manually test the functionality in commit "Add OpenAPI 3 non-trivial instances"

For #553 

Retrievable with

```
nix run .#internal-hercules-gen-swagger -- --openapi3 | jq . >openapi3-draft.json
```