### PR TITLE
Effect mounts

### DIFF
--- a/docs/modules/ROOT/pages/agent-config.adoc
+++ b/docs/modules/ROOT/pages/agent-config.adoc
@@ -96,6 +96,63 @@ NOTE: When scaling, it is generally better to have a double-size machine than tw
 because each split of resources causes inefficiencies; particularly with regards
 to build latency because of extra downloads.
 
+[[effectMountables]]
+== effectMountables
+
+_Since hercules-ci-agent 0.10.1_
+
+Default: `{ }`
+
+A mapping from names to mountable definitions.
+
+Example value:
+```nix
+{
+  "hosts" = {
+    source = "/etc/hosts";
+    readOnly = true;
+    condition = {
+      isRepo = "configurations";
+    };
+  };
+}
+```
+
+Mountables can be mounted into the filesystem of effects that satisfy the condition, and request a mount using xref:effects/declaration.adoc#\__hci_mounts[`__hci_mounts`].
+
+The location in the sandbox is not configured here, but in the field names of xref:effects/declaration.adoc#\__hci_mounts[`__hci_mounts`].
+
+You may visualize the mounting process as the joining of the two maps:
+
+----
+                     effect                    agent
+
+┌──────────────┐  __hci_mounts  ┌──────┐  effectMountables  ┌───────────┐
+│ sandbox path ├───────────────►│ name ├───────────────────►│ mountable │
+└──────────────┘                └──────┘                    └───────────┘
+
+virtual location               convention                   host location
+----
+
+Attributes:
+
+[[effectMountables-source]]
+=== source
+
+The location on the host system that can be mounted into an effect's sandbox.
+Make sure that the system user running hercules-ci-agent is allowed to access this location.
+
+[[effectMountables-readOnly]]
+=== readOnly
+
+If `true`, the mount into the sandbox will be a read-only bind mount.
+If `false`, the mount is not mounted read-only, and it will be writable if it is for the user that runs hercules-ci-agent.
+
+[[effectMountables-condition]]
+=== condition
+
+A xref:secrets-json.adoc#condition[condition expression] that controls under what circumstances an effect is allowed to mount this mountable.
+
 [[remotePlatformsWithSameFeatures]]
 == remotePlatformsWithSameFeatures
 

--- a/docs/modules/ROOT/pages/agent-config.adoc
+++ b/docs/modules/ROOT/pages/agent-config.adoc
@@ -181,7 +181,9 @@ Values involving arrays of non-primitive types may not be representable currentl
 [[logLevel]]
 == logLevel
 
-Optional. Defaults to `"InfoS"`. More verbose: `"DebugS"`, less verbose: `"WarningS"`, `"ErrorS"`.
+Optional. Control the importance threshold for messages are logged to the system log.
+
+Defaults to `"InfoS"`. More verbose: `"DebugS"`, less verbose: `"WarningS"`, `"ErrorS"`.
 
 [[nixVerbosity]]
 == nixVerbosity

--- a/docs/modules/ROOT/pages/effects.adoc
+++ b/docs/modules/ROOT/pages/effects.adoc
@@ -11,7 +11,7 @@ Effects run as part of a xref:hercules-ci:ROOT:glossary.adoc#job[job], after all
 
 == Sandbox type
 
-Currently, effects run in Linux containers only. Note that you _can_ deploy to a macOS machine via SSH from a Linux agent using e.g. xref:hercules-ci-effects:ROOT:reference/nix-functions/runNixDarwin.adoc[hercules-ci-effects runNixDarwin].
+Currently, effects run only run on Linux containers only, in a transient container. Note that you _can_ deploy to a macOS machine via SSH from a Linux agent using e.g. xref:hercules-ci-effects:ROOT:reference/nix-functions/runNixDarwin.adoc[hercules-ci-effects runNixDarwin].
 
 [[paths]]
 == Paths
@@ -67,6 +67,7 @@ A slash separated string containing in order: the site name (typically `github`)
 
 Example: `github/hercules-ci/hercules-ci-agent`
 
+[[secrets]]
 == Secrets
 
 The `secretsMap` declares what secrets should be provided to the effect.

--- a/docs/modules/ROOT/pages/effects/declaration.adoc
+++ b/docs/modules/ROOT/pages/effects/declaration.adoc
@@ -1,0 +1,32 @@
+= Effect Declaration
+
+Effects are declared by means of a Nix derivation, and just like Nix shells, they are not built normally.
+Instead, they execute in a special sandbox that can be customized with the following derivation attributes. This page explains how the derivation is interpreted by Hercules CI Agent.
+
+For writing your own effects, it is recommended to use xref:hercules-ci-effects:ROOT:reference/effect-modules/core.adoc[the hercules-ci-effects attribute documentation]. The rest of this page is reference documentation for effects interface.
+
+
+[[attributes]]
+== Attributes
+
+Output-related derivation attributes are mostly ignored.
+
+Currently, `__structuredAttributes` must not be used in effects. It can be used in dependencies of the effect just fine.
+
+[[__hci_mounts]]
+=== `__hci_mounts`
+
+_Since hercules-ci-agent 0.10.1_
+
+A JSON object where the field names are paths in the sandbox filesystem, and the values are strings that refer to xref:../agent-config.adoc#effectMountables[effect mountables] configured on the agent.
+
+Example:
+
+```json
+{ "/etc/hosts": "hosts" }
+```
+
+[[secretsMap]]
+=== `secretsMap`
+
+See (low-level) xref:../effects.adoc#secrets[Secrets] or xref:hercules-ci-effects:ROOT:reference/effect-modules/core.adoc[hercules-ci-effects secretsMap option].

--- a/docs/modules/ROOT/pages/secrets-json.adoc
+++ b/docs/modules/ROOT/pages/secrets-json.adoc
@@ -66,7 +66,11 @@ The language consists of the following constructs, all of which evaluate to bool
 
 `{"*isOwner*": s}`: true only when the Effect is part of a Job that originates from a repository owned by an account whose name is exactly equal to the string `s`. Note that jobs do not currently run for PRs from other owner's repositories, but this is planned to change.
 
-NOTE: The lack of a "not" construct isn't unintentional, because block lists are generally not fail-safe. It could be added nonetheless if the need arises.
+`true`: evaluates to true; allow. Equivalent to `{"and":[]}`.
+
+`false`: evaluates to false; deny. Equivalent to `{"or":[]}`.
+
+NOTE: The lack of a "not" construct isn't unintentional, because block lists are fundamentally not safe under renames or additions. It could be added nonetheless if the need arises.
 
 Secrets that are used for a single purpose can often be represented by a single "and", whereas secrets that are used in multiple ways may need an "or" of "ands" where each "and" describes one situation where the secret may be used.
 

--- a/docs/modules/ROOT/partials/nav-items.adoc
+++ b/docs/modules/ROOT/partials/nav-items.adoc
@@ -8,6 +8,7 @@
 * xref:job-definition.adoc[Job Definition]
 ** xref:evaluation.adoc[Evaluation]
 ** xref:effects.adoc[Effects]
+*** xref:effects/declaration.adoc[Effect Declaration]
 ** xref:legacy-evaluation.adoc[Legacy Evaluation]
 * Security Reference
 ** xref:data-sharing.adoc[Data sharing overview]

--- a/flake.nix
+++ b/flake.nix
@@ -280,7 +280,14 @@
                 internal = {
 
                   devShell.extraLibraries = hp: {
-                    inherit (hp) releaser;
+                    inherit (hp) releaser
+                      ascii-progress
+
+                      # enable only when working on expr and up
+                      # hercules-ci-cnix-store
+                      # cachix
+
+                      ;
                     # Cachix deps (cachix was excluded because of its dependency on cnix-store)
                   } //
                   lib.listToAttrs (

--- a/hercules-ci-agent/CHANGELOG.md
+++ b/hercules-ci-agent/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Effect mounts. Specify [`effectMountables`](https://docs.hercules-ci.com/hercules-ci-agent/agent-config.html#effectMountables) in the agent configuration, deploy, and [mount](https://docs.hercules-ci.com/hercules-ci-agent/effects/declaration.html#__hci_mounts) them into an effect. This can be used for instance to expose the host's `/etc/hosts`, or hardware devices such as GPUs. Access is [controlled](https://docs.hercules-ci.com/hercules-ci-agent/agent-config.html#effectMountables-condition) by the agent configuration.
+
  - New configuration option `remotePlatformsWithSameFeatures`, allowing a remote build to be used before more elaborate remote builder support is implemented.
    The recommended method for running a cluster is still to install `hercules-ci-agent` on each machine, as that is more efficient and accurate.
 

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Effect.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Effect.hs
@@ -27,6 +27,7 @@ runEffect extraNixOptions store command = do
         runEffectToken = Just $ Command.Effect.token command,
         runEffectSecretsConfigPath = Just $ Command.Effect.secretsPath command,
         runEffectServerSecrets = Command.Effect.serverSecrets command <&> fromViaJSON,
+        runEffectConfiguredMountables = Command.Effect.configuredMountables command <&> fromViaJSON,
         runEffectApiBaseURL = Command.Effect.apiBaseURL command,
         runEffectDir = dir,
         runEffectProjectId = Just $ Command.Effect.projectId command,

--- a/hercules-ci-agent/hercules-ci-agent.cabal
+++ b/hercules-ci-agent/hercules-ci-agent.cabal
@@ -470,6 +470,7 @@ test-suite hercules-ci-agent-unit-tests
     , transformers
     , transformers-base
     , unliftio-core
+    , unordered-containers
     , uuid
     , vector
   build-tool-depends:

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config/Combined.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Config/Combined.hs
@@ -41,5 +41,8 @@ boolAtKey k = Combi (Data.Bifunctor.Product.Pair (Toml.bool k) (Json.bool k))
 opt :: Combi' a -> Combi' (Maybe a)
 opt x = Combi $ Pair (Toml.dioptional (forToml x)) (Json.proOptional (forJson x))
 
+optEmpty :: (Monoid a) => Combi' a -> Combi' a
+optEmpty c = dimap Just (fromMaybe mempty) (opt c)
+
 enumBoundedAtKey :: (Bounded a, Enum a, Show a) => Key -> Combi' a
 enumBoundedAtKey k = Combi (Data.Bifunctor.Product.Pair (Toml.enumBounded k) (Json.enumBounded k))

--- a/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Effect.hs
+++ b/hercules-ci-agent/hercules-ci-agent/Hercules/Agent/Effect.hs
@@ -75,7 +75,8 @@ performEffect sendLogEntries effectTask = withWorkDir "effect" $ \workDir -> do
                     repoName = EffectTask.repoName effectTask,
                     ref = EffectTask.ref effectTask,
                     isDefaultBranch = EffectTask.isDefaultBranch effectTask
-                  }
+                  },
+              configuredMountables = Sensitive (ViaJSON (Config.effectMountables config))
             }
   let stderrHandler =
         stderrLineHandler

--- a/hercules-ci-agent/src/Hercules/Agent/WorkerProtocol/Command/Effect.hs
+++ b/hercules-ci-agent/src/Hercules/Agent/WorkerProtocol/Command/Effect.hs
@@ -9,6 +9,7 @@ import Hercules.API.Id (Id)
 import Hercules.Agent.Sensitive
 import Hercules.Agent.WorkerProtocol.Orphans ()
 import Hercules.Agent.WorkerProtocol.ViaJSON (ViaJSON)
+import Hercules.Formats.Mountable (Mountable)
 import Hercules.Secrets (SecretContext)
 import Protolude
 
@@ -21,6 +22,7 @@ data Effect = Effect
     token :: Sensitive Text,
     projectId :: Id "project",
     projectPath :: Text,
-    secretContext :: SecretContext
+    secretContext :: SecretContext,
+    configuredMountables :: Sensitive (ViaJSON (Map Text (Mountable)))
   }
   deriving (Generic, Binary, Show, Eq)

--- a/hercules-ci-agent/src/Hercules/Secrets.hs
+++ b/hercules-ci-agent/src/Hercules/Secrets.hs
@@ -80,6 +80,9 @@ evalCondition' ctx = eval
       if actual == expect
         then pure True
         else False <$ tell ["isOwner: owner " <> show actual <> " is not the desired " <> show expect]
+    eval (Hercules.Formats.Secret.Const b) = do
+      tell ["const: " <> show b]
+      pure b
 
 -- This uses tagless final to derive both an efficient and a tracing function.
 

--- a/hercules-ci-agent/test/Hercules/Agent/ConfigSpec.hs
+++ b/hercules-ci-agent/test/Hercules/Agent/ConfigSpec.hs
@@ -12,6 +12,9 @@ import Hercules.Agent.Config (Config (..), Purpose (Input), combiCodec)
 import Hercules.Agent.Config.Combined (forJson, forToml)
 import Hercules.Agent.Config.Json qualified as Json
 import Hercules.CNix.Verbosity (Verbosity (Vomit))
+import Hercules.Formats.Mountable (Mountable (Mountable))
+import Hercules.Formats.Mountable qualified
+import Hercules.Formats.Secret qualified
 import Katip (Severity (DebugS))
 import Protolude
 import Test.Hspec
@@ -42,14 +45,12 @@ spec =
                   "workDirectory = \"/var/lib/hercules-ci-agent/work\"",
                   "remotePlatformsWithSameFeatures = [\"aarch64-darwin\"]",
                   "nixVerbosity = \"vomit\"",
-                  -- -- This line should not be needed!
-                  -- "[effectMountables]",
-
-                  -- "[effectMountables.hosts]",
-                  -- "  condition = true",
-                  -- "  readOnly = true",
-                  -- "  source = \"/etc/hosts\"",
-
+                  -- This line should not be needed!
+                  "[effectMountables]",
+                  "[effectMountables.hosts]",
+                  "  condition = true",
+                  "  readOnly = true",
+                  "  source = \"/etc/hosts\"",
                   "[labels]",
                   "module = \"nixos-profile\"",
                   "[labels.agent]",
@@ -80,18 +81,17 @@ spec =
                           ]
                       ),
                   allowInsecureBuiltinFetchers = Just True,
-                  remotePlatformsWithSameFeatures = Just ["aarch64-darwin"]
-                  -- ,
-                  -- effectMountables =
-                  --   M.fromList
-                  --     [ ( "hosts",
-                  --         Mountable
-                  --           { source = "/etc/hosts",
-                  --             readOnly = True,
-                  --             condition = Hercules.Formats.Secret.Const True
-                  --           }
-                  --       )
-                  --     ]
+                  remotePlatformsWithSameFeatures = Just ["aarch64-darwin"],
+                  effectMountables =
+                    M.fromList
+                      [ ( "hosts",
+                          Mountable
+                            { source = "/etc/hosts",
+                              readOnly = True,
+                              condition = Hercules.Formats.Secret.Const True
+                            }
+                        )
+                      ]
                 }
             )
       it "parses empty config" $ do
@@ -125,6 +125,14 @@ spec =
                   "  \"lib\": {\"version\": \"24.05pre-git\"},",
                   "  \"module\": \"nixos-profile\"",
                   "},",
+                  "\"effectMountables\": {",
+                  "  \"hosts\": {",
+                  "    \"source\": \"/etc/hosts\",",
+                  "    \"readOnly\": true,",
+                  "    \"condition\": true,",
+                  "    \"and\":[]",
+                  "  }",
+                  "},",
                   "\"allowInsecureBuiltinFetchers\": true",
                   "}"
                 ]
@@ -151,7 +159,17 @@ spec =
                         ]
                     ),
                 allowInsecureBuiltinFetchers = Just True,
-                remotePlatformsWithSameFeatures = Just ["aarch64-darwin"]
+                remotePlatformsWithSameFeatures = Just ["aarch64-darwin"],
+                effectMountables =
+                  M.fromList
+                    [ ( "hosts",
+                        Mountable
+                          { source = "/etc/hosts",
+                            readOnly = True,
+                            condition = Hercules.Formats.Secret.Const True
+                          }
+                      )
+                    ]
               }
 
       it "handles empty config" $ do
@@ -213,5 +231,6 @@ emptyConfig =
       nixVerbosity = Nothing,
       labels = Nothing,
       allowInsecureBuiltinFetchers = Nothing,
-      remotePlatformsWithSameFeatures = Nothing
+      remotePlatformsWithSameFeatures = Nothing,
+      effectMountables = mempty
     }

--- a/hercules-ci-api-agent/hercules-ci-api-agent.cabal
+++ b/hercules-ci-api-agent/hercules-ci-api-agent.cabal
@@ -68,6 +68,7 @@ library
     Hercules.API.TaskStatus
     Hercules.Formats.CachixCache
     Hercules.Formats.Common
+    Hercules.Formats.Mountable
     Hercules.Formats.NixCache
     Hercules.Formats.Secret
 
@@ -131,6 +132,7 @@ test-suite hercules-ci-api-agent-unit-tests
     Hercules.API.Agent.LifeCycle.AgentInfoSpec
     Hercules.Formats.CachixCacheSpec
     Hercules.Formats.SecretSpec
+    Hercules.Formats.MountableSpec
     Spec
 
   hs-source-dirs:     test

--- a/hercules-ci-api-agent/src/Hercules/Formats/Mountable.hs
+++ b/hercules-ci-api-agent/src/Hercules/Formats/Mountable.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Hercules.Formats.Mountable where
+
+import qualified Data.Aeson as A
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Hercules.Formats.Secret (Condition)
+import Prelude (Bool, Eq, Show)
+
+data Mountable = Mountable
+  { -- | A path on the host.
+    source :: !Text,
+    readOnly :: !Bool,
+    condition :: !Condition
+  }
+  deriving (Generic, Show, Eq, A.ToJSON, A.FromJSON)

--- a/hercules-ci-api-agent/src/Hercules/Formats/Secret.hs
+++ b/hercules-ci-api-agent/src/Hercules/Formats/Secret.hs
@@ -21,6 +21,7 @@ data Condition
   | IsTag
   | IsRepo Text
   | IsOwner Text
+  | Const Bool
   deriving (Generic, Eq, Read, Show)
 
 instance ToJSON Condition where
@@ -31,6 +32,7 @@ instance ToJSON Condition where
   toJSON (IsBranch a) = object ["isBranch" .= a]
   toJSON (IsRepo a) = object ["isRepo" .= a]
   toJSON (IsOwner a) = object ["isOwner" .= a]
+  toJSON (Const b) = Bool b
 
 instance FromJSON Condition where
   parseJSON (String "isTag") = pure IsTag
@@ -42,7 +44,8 @@ instance FromJSON Condition where
         Nothing -> fail $ "The field name in a Condition object must be one of " <> show (map fst (HM.toList taggedConditionParsers))
         Just p -> p v
       _ -> fail "A Condition object must contain a single field."
-  parseJSON _ = fail "Expected Object or String."
+  parseJSON (Bool b) = pure (Const b)
+  parseJSON _ = fail "Expected Object, String or true."
 
 taggedConditionParsers :: HM.HashMap Text (Value -> A.Parser Condition)
 taggedConditionParsers =

--- a/hercules-ci-api-agent/src/Hercules/Formats/Secret.hs
+++ b/hercules-ci-api-agent/src/Hercules/Formats/Secret.hs
@@ -65,50 +65,6 @@ taggedConditionParsers =
       ("isOwner", fmap IsOwner . parseJSON)
     ]
 
-{-
-
-This was awful:
-
-instance FromJSON Condition where
-  parseJSON (String "isTag") = pure IsTag
-  parseJSON (String "isDefaultBranch") = pure IsDefaultBranch
-  parseJSON j = do
-    l <- parseJSON j
-    case l of
-      [] -> fail "The empty list does not represent a Condition."
-      (jTag : args) -> do
-        tag <- parseJSON jTag
-        case tag :: Text of
-          "or" -> do
-            Or <$> traverse parseJSON args
-          "and" -> do
-            And <$> traverse parseJSON args
-          "isDefaultBranch" -> do
-            IsDefaultBranch <$ noParams tag args
-          "isTag" -> do
-            IsTag <$ noParams tag args
-          "isBranch" -> do
-            IsBranch <$> traverse parseJSON args
-          "isRepo" -> do
-            IsRepo <$> traverse parseJSON args
-          "isOwner" -> do
-            IsOwner <$> traverse parseJSON args
-          t -> do
-            fail $ "Unknown tag " <> show t <> " in Condition."
-    where
-      noParams _ [] = pure ()
-      noParams tag _ = fail $ "Condition with tag " <> show tag <> " does not take any parameters."
-
-instance ToJSON Condition where
-  toJSON (Or a) = toJSON (String "or" : map toJSON a)
-  toJSON (And a) = toJSON (String "and" : map toJSON a)
-  toJSON IsDefaultBranch = String "isDefaultBranch"
-  toJSON IsTag = String "isTag"
-  toJSON (IsBranch a) = toJSON (String "isBranch" : map toJSON a)
-  toJSON (IsRepo a) = toJSON (String "isRepo" : map toJSON a)
-  toJSON (IsOwner a) = toJSON (String "isOwner" : map toJSON a)
--}
-
 -- | Arbitrary secret like keys, tokens, passwords etc.
 data Secret = Secret
   { data_ :: Map Text Value,

--- a/hercules-ci-api-agent/test/Hercules/Formats/MountableSpec.hs
+++ b/hercules-ci-api-agent/test/Hercules/Formats/MountableSpec.hs
@@ -1,0 +1,28 @@
+module Hercules.Formats.MountableSpec (spec) where
+
+import qualified AesonSupport as Aeson
+import Data.Aeson (eitherDecode)
+import Hercules.Formats.Mountable (Mountable (..))
+import Hercules.Formats.Secret (Condition (IsDefaultBranch, Or))
+import Hercules.Formats.SecretSpec (genCondition, genText)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.QuickCheck (Gen, arbitrary)
+import Prelude
+
+spec :: Spec
+spec = describe "Mountable" $ do
+  Aeson.checkLaws genMountable
+  it "Decodes example 1" $
+    eitherDecode
+      "{ \"source\": \"the source\", \"readOnly\": false, \"condition\": {\"or\": [\"isDefaultBranch\"]} }"
+      `shouldBe` Right
+        ( Mountable
+            { source = "the source",
+              readOnly = False,
+              condition = Or [IsDefaultBranch]
+            }
+        )
+
+genMountable :: Gen Mountable
+genMountable =
+  Mountable <$> genText <*> arbitrary <*> genCondition

--- a/hercules-ci-api-agent/test/Hercules/Formats/SecretSpec.hs
+++ b/hercules-ci-api-agent/test/Hercules/Formats/SecretSpec.hs
@@ -64,7 +64,7 @@ genSecret =
     6
     ( Secret
         <$> liftArbitraryMap text (resize 100 genValue)
-        <*> frequency [(1, pure Nothing), (19, Just <$> genCondition)]
+        <*> frequency [(1, pure Nothing), (17, Just <$> genCondition)]
     )
 
 genCondition :: Gen Condition
@@ -76,11 +76,13 @@ genCondition =
       (1, pure IsTag),
       (1, IsBranch <$> text),
       (1, IsRepo <$> text),
-      (1, IsOwner <$> text)
+      (1, IsOwner <$> text),
+      (1, Hercules.Formats.Secret.Const <$> arbitrary)
     ]
 
-text :: Gen Text
+genText, text :: Gen Text
 text = TE.decodeUtf8 . TE.encodeUtf8 . T.pack <$> resize 4 arbitrary
+genText = text
 
 liftArbitraryMap :: (Ord k) => Gen k -> Gen a -> Gen (M.Map k a)
 liftArbitraryMap k v = M.fromList <$> liftArbitrary ((,) <$> k <*> v)

--- a/hercules-ci-api-agent/test/Spec.hs
+++ b/hercules-ci-api-agent/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEffectEventS
 import qualified Hercules.API.Agent.Evaluate.EvaluateEvent.DerivationInfoSpec
 import qualified Hercules.API.Agent.LifeCycle.AgentInfoSpec
 import qualified Hercules.Formats.CachixCacheSpec
+import qualified Hercules.Formats.MountableSpec
 import qualified Hercules.Formats.SecretSpec
 import Test.Hspec
 
@@ -22,5 +23,7 @@ spec = describe "hercules-ci-api" do
     Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEffectEventSpec.spec
   describe "Hercules.Formats.CachixCache" do
     Hercules.Formats.CachixCacheSpec.spec
+  describe "Hercules.Formats.Mountable" do
+    Hercules.Formats.MountableSpec.spec
   describe "Hercules.Formats.Secret" do
     Hercules.Formats.SecretSpec.spec

--- a/hercules-ci-cli/src/Hercules/CLI/Effect.hs
+++ b/hercules-ci-cli/src/Hercules/CLI/Effect.hs
@@ -118,7 +118,8 @@ runParser = do
                   runEffectSecretContext = secretContextMaybe,
                   runEffectUseNixDaemonProxy = False, -- FIXME Enable proxy for ci/dev parity. Requires access to agent binaries. Unified executable?
                   runEffectExtraNixOptions = [],
-                  runEffectFriendly = True
+                  runEffectFriendly = True,
+                  runEffectConfiguredMountables = mempty -- FIXME: provide hosts?
                 }
         throwIO exitCode
 

--- a/internal/nix/common.nix
+++ b/internal/nix/common.nix
@@ -21,8 +21,9 @@ let
   mdDoc = lib.mdDoc or (x: "Documentation not rendered. Please upgrade to a newer NixOS with markdown support.");
 
   cfg = config.services.hercules-ci-agent;
+  opt = options.services.hercules-ci-agent;
 
-  inherit (import ./settings.nix { inherit pkgs lib; }) format settingsModule;
+  inherit (import ./settings.nix { inherit pkgs lib; }) format makeSettingsOptions;
 
 in
 {
@@ -54,16 +55,6 @@ in
       default = pkgs.hercules-ci-agent;
       defaultText = literalExpression "pkgs.hercules-ci-agent";
     };
-    settings = mkOption {
-      description = mdDoc ''
-        These settings are written to the `agent.json` file.
-
-        Not all settings are listed as options, can be set nonetheless.
-
-        For the exhaustive list of settings, see <https://docs.hercules-ci.com/hercules-ci/reference/agent-config/>.
-      '';
-      type = types.submoduleWith { modules = [ settingsModule ]; };
-    };
 
     /*
       Internal and/or computed values.
@@ -79,7 +70,7 @@ in
         The fully assembled config file.
       '';
     };
-  };
+  } // makeSettingsOptions { inherit cfg opt; };
 
   config = mkIf cfg.enable {
     # Make sure that nix.extraOptions does not override trusted-users

--- a/internal/nix/nixos/multi.nix
+++ b/internal/nix/nixos/multi.nix
@@ -10,7 +10,7 @@ let
 
   submodule = { config, options, name, ... }:
     let
-      inherit (import ../settings.nix { inherit pkgs lib; }) format settingsModule;
+      inherit (import ../settings.nix { inherit pkgs lib; }) format makeSettingsOptions;
       configFile = format.generate "hercules-ci-agent${suffix}.json" config.settings;
       command = "${config.package}/bin/hercules-ci-agent --config ${configFile}";
       testCommand = "${command} --test-configuration";
@@ -31,17 +31,7 @@ let
           default = pkgs.hercules-ci-agent;
           defaultText = literalExpression "pkgs.hercules-ci-agent";
         };
-        settings = mkOption {
-          description = ''
-            These settings are written to the `agent.json` file.
-
-            Not all settings are listed as options, can be set nonetheless.
-
-            For the exhaustive list of settings, see <https://docs.hercules-ci.com/hercules-ci/reference/agent-config/>.
-          '';
-          type = types.submoduleWith { modules = [ settingsModule ]; };
-        };
-      };
+      } // makeSettingsOptions { cfg = config; opt = options; };
       config = let cfg = config; in
         {
           settings = {

--- a/tests/agent-test.nix
+++ b/tests/agent-test.nix
@@ -85,6 +85,25 @@ in
             source = "/etc/hosts";
             condition = true;
           };
+          "test-condition-type" = {
+            readOnly = true;
+            source = "/dev/null";
+            # bogus expression that contains examples of all possible conditions
+            condition = {
+              or = [
+                { isOwner = "hercules-ci"; }
+                { isRepo = "repo-with-shared-data"; }
+                { isBranch = "main"; }
+                "isTag"
+                {
+                  and = [
+                    "isDefaultBranch"
+                    { isBranch = "master"; }
+                  ];
+                }
+              ];
+            };
+          };
         };
 
         systemd.services.hercules-ci-agent.serviceConfig.StartLimitBurst = lib.mkForce (agentStartTimeoutSec * 10);

--- a/tests/agent-test.nix
+++ b/tests/agent-test.nix
@@ -44,7 +44,10 @@ in
       ];
       config = {
         # Keep build dependencies around, because we'll be offline
-        environment.etc."reference-stdenv".text = builtins.toJSON (pkgs.runCommand "foo" { } "").drvAttrs;
+        environment.etc."reference-stdenv".text = builtins.toJSON (pkgs.runCommand "foo"
+          {
+            nativeBuildInputs = [ pkgs.curl ];
+          } "").drvAttrs;
         # It's an offline test, so no caches are available
         nix.settings.substituters = lib.mkForce [ ];
         nix.package = lib.mkIf daemonIsNixUnstable pkgs.nixUnstable;
@@ -59,6 +62,8 @@ in
         services.hercules-ci-agent.settings.binaryCachesPath = (pkgs.writeText "binary-caches.json" (builtins.toJSON { })).outPath;
         services.hercules-ci-agent.settings.clusterJoinTokenPath = (pkgs.writeText "pretend-agent-token" "").outPath;
         services.hercules-ci-agent.settings.concurrentTasks = 4; # Decrease on itest memory problems
+        # services.hercules-ci-agent.settings.logLevel = "DebugS";
+        # services.hercules-ci-agent.settings.nixVerbosity = "debug";
         services.hercules-ci-agent.settings.effectMountables = {
           "forwarded-path" = {
             source = pkgs.runCommand "forwarded-path" { } ''
@@ -74,6 +79,11 @@ in
             condition = {
               isRepo = "repo-with-shared-data";
             };
+          };
+          "hosts" = {
+            readOnly = true;
+            source = "/etc/hosts";
+            condition = true;
           };
         };
 

--- a/tests/agent-test/hercules-ci-agent-test.cabal
+++ b/tests/agent-test/hercules-ci-agent-test.cabal
@@ -26,6 +26,7 @@ executable hercules-ci-agent-test
       AgentTask
       BuildSpec
       DummyApi
+      EffectSpec
       EvaluationSpec
       MockTasksApi
       Spec

--- a/tests/agent-test/src/AgentTask.hs
+++ b/tests/agent-test/src/AgentTask.hs
@@ -5,6 +5,7 @@ module AgentTask where
 import Hercules.API.Agent.Build.BuildTask
   ( BuildTask,
   )
+import Hercules.API.Agent.Effect.EffectTask (EffectTask)
 import Hercules.API.Agent.Evaluate.EvaluateTask
   ( EvaluateTask,
   )
@@ -13,4 +14,5 @@ import Hercules.API.Prelude
 data AgentTask
   = Evaluate EvaluateTask
   | Build BuildTask
+  | Effect EffectTask
   deriving (Generic, Show, Eq, ToJSON, FromJSON)

--- a/tests/agent-test/src/EffectSpec.hs
+++ b/tests/agent-test/src/EffectSpec.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module EffectSpec where
+
+import Control.Concurrent.STM.TVar (readTVar)
+import Data.Aeson qualified as A
+import Data.Map qualified as M
+import Data.UUID.V4 qualified as UUID
+import Hercules.API.Agent.Effect.EffectTask qualified as EffectTask
+import Hercules.API.Agent.Evaluate.EvaluateEvent (EvaluateEvent)
+import Hercules.API.Agent.Evaluate.EvaluateEvent qualified as EvaluateEvent
+import Hercules.API.Agent.Evaluate.EvaluateEvent.AttributeEffectEvent qualified as AttributeEffectEvent
+import Hercules.API.Agent.Evaluate.EvaluateTask qualified as EvaluateTask
+import Hercules.API.Agent.Evaluate.EvaluateTask.OnPush qualified as EvaluateTask.OnPush
+import Hercules.API.Agent.Evaluate.ImmutableInput qualified as ImmutableInput
+import Hercules.API.Id (Id (Id))
+import Hercules.API.Logs.LogEntry qualified as LogEntry
+import Hercules.API.TaskStatus qualified as TaskStatus
+import MockTasksApi
+import Protolude
+import System.Timeout (timeout)
+import Test.Hspec
+import TestSupport (apiBaseUrl)
+import Prelude
+  ( error,
+    userError,
+  )
+import Prelude qualified
+
+randomId :: IO (Id a)
+randomId = Id <$> UUID.nextRandom
+
+failWith :: [Char] -> IO a
+failWith = throwIO . userError
+
+defaultEvalTask :: EvaluateTask.EvaluateTask
+defaultEvalTask =
+  EvaluateTask.EvaluateTask
+    { id = Prelude.error "override EvaluateTask.id please",
+      primaryInput = mempty,
+      otherInputs = mempty,
+      autoArguments = mempty,
+      inputs = mempty,
+      inputMetadata = mempty,
+      nixPath = mempty,
+      logToken = "mock-eval-log-token",
+      selector = EvaluateTask.ConfigOrLegacy,
+      ciSystems = Nothing,
+      extraGitCredentials = mempty,
+      isFlakeJob = False
+    }
+
+defaultMeta :: Map Text A.Value
+defaultMeta =
+  "rev"
+    =: A.String "eefe2e4df3a0f147cf0f59438010b63fd857291b"
+    <> "ref"
+    =: "refs/heads/main"
+
+attrLike :: [EvaluateEvent] -> [EvaluateEvent]
+attrLike = filter isAttrLike
+
+isAttrLike :: EvaluateEvent -> Bool
+isAttrLike EvaluateEvent.Attribute {} = True
+isAttrLike EvaluateEvent.AttributeError {} = True
+isAttrLike EvaluateEvent.AttributeEffect {} = True
+isAttrLike EvaluateEvent.Message {} = True -- this is a bit of a stretch but hey
+isAttrLike _ = False
+
+(=:) :: k -> a -> Map k a
+(=:) = M.singleton
+
+printErrItems :: (Foldable t, MonadIO f, Show a) => t a -> f ()
+printErrItems items = for_ items \item -> putErrText ("  - " <> show item)
+
+spec :: SpecWith ServerHandle
+spec = describe "Effect" do
+  it "works" $ \srv -> do
+    -- Setup: put the drv in the agent's store
+    id <- randomId
+    (s, r) <-
+      runEval
+        srv
+        ( fixupInputs
+            defaultEvalTask
+              { EvaluateTask.id = id,
+                EvaluateTask.otherInputs = "src" =: "/tarball/effect" <> "n" =: "/tarball/nixpkgs",
+                EvaluateTask.autoArguments =
+                  M.singleton
+                    "nixpkgs"
+                    (EvaluateTask.SubPathOf "n" Nothing),
+                EvaluateTask.inputMetadata = "src" =: defaultMeta,
+                EvaluateTask.selector = EvaluateTask.OnPush $ EvaluateTask.OnPush.MkOnPush {name = "cd", inputs = "nixpkgs" =: ImmutableInput.ArchiveUrl (apiBaseUrl <> "/tarball/nixpkgs")}
+              }
+        )
+    s `shouldBe` TaskStatus.Successful ()
+    drvPath <-
+      case attrLike r of
+        [EvaluateEvent.AttributeEffect ev] -> do
+          let drvPath = AttributeEffectEvent.derivationPath ev
+          AttributeEffectEvent.expressionPath ev `shouldBe` ["effects", "launchIt"]
+          toS drvPath `shouldContain` "/nix/store"
+          pure drvPath
+        attrEvs -> do
+          putText "All events:"
+          printErrItems r
+          failWith $ "Events should be a single attribute, not: " <> show attrEvs
+    -- Test: launch it
+    id2 <- randomId
+    s2 <-
+      runEffect
+        srv
+        ( EffectTask.EffectTask
+            { id = id2,
+              derivationPath = drvPath,
+              logToken = "pretend-jwt-for-log",
+              inputDerivationOutputPaths = [],
+              token = "test-fake-token",
+              projectId = Id $ Prelude.read "00000000-0000-0000-0000-000000001234",
+              projectPath = "github/test-fake-owner/test-fake-repo",
+              serverSecrets = mempty,
+              siteName = "test-fake-site",
+              ownerName = "test-fake-owner",
+              repoName = "test-fake-repo",
+              ref = "refs/heads/test-fake-branch",
+              isDefaultBranch = True
+            }
+        )
+    s2 `shouldBe` TaskStatus.Successful ()
+    x <- timeout 30_000_000 do
+      atomically do
+        entries <- readTVar (logEntries $ serverState srv)
+        guard $
+          isJust $
+            entries & find \case LogEntry.Msg {msg = m} | m == "hello on stderr\r" -> True; _noMatch -> False
+        guard $
+          isJust $
+            entries & find \case LogEntry.Msg {msg = m} | m == "hello on stdout\r" -> True; _noMatch -> False
+        guard $
+          isJust $
+            entries & find \case LogEntry.Msg {msg = m} | m == "hi from src\r" -> True; _noMatch -> False
+      -- FIXME
+      -- guard $
+      --   isJust $
+      --     entries & find \case LogEntry.Result { msg = m } | m == "log line without newline\r" -> True; _noMatch -> False
+      pass
+    case x of
+      Nothing -> do
+        printErrItems =<< atomically (readTVar (logEntries $ serverState srv))
+        failWith "Did not receive satisfactory log in time."
+      Just _ -> pass

--- a/tests/agent-test/src/EffectSpec.hs
+++ b/tests/agent-test/src/EffectSpec.hs
@@ -207,6 +207,9 @@ spec = describe "Effect" do
         guard $
           isJust $
             entries & find \case LogEntry.Msg {msg = m} | m == "hello from shared-data\r" -> True; _noMatch -> False
+        guard $
+          isJust $
+            entries & find \case LogEntry.Msg {msg = m} | m == "Hello, world! - The fake API testing endpoint\r" -> True; _noMatch -> False
       -- FIXME
       -- guard $
       --   isJust $

--- a/tests/agent-test/src/MockTasksApi.hs
+++ b/tests/agent-test/src/MockTasksApi.hs
@@ -314,6 +314,7 @@ type MockAPI =
     :<|> "api" :> "v1" :> "agent-socket" :> WebSocket
     :<|> "api" :> "v1" :> "logs" :> "build" :> "socket" :> WebSocket
     :<|> "tarball" :> Capture "tarball" Text :> StreamGet NoFraming OctetStream (SourceIO ByteString)
+    :<|> "hello" :> Get '[PlainText] Text
 
 mockApi :: Proxy MockAPI
 mockApi = Proxy
@@ -348,6 +349,7 @@ endpoints server =
     :<|> socket server
     :<|> logSocket server
     :<|> (toSourceIO & liftA & liftA & ($ sourceball))
+    :<|> pure "Hello, world! - The fake API testing endpoint\n"
 
 logSocket :: ServerState -> Network.WebSockets.Connection.Connection -> Handler ()
 logSocket server conn = do

--- a/tests/agent-test/src/Spec.hs
+++ b/tests/agent-test/src/Spec.hs
@@ -1,11 +1,13 @@
 module Spec where
 
 import BuildSpec qualified
+import EffectSpec qualified
 import EvaluationSpec qualified
 import MockTasksApi (ServerHandle)
 import Test.Hspec
 
 spec :: SpecWith ServerHandle
 spec = do
+  EffectSpec.spec
   EvaluationSpec.spec
   BuildSpec.spec

--- a/tests/agent-test/testdata/effect/default.nix
+++ b/tests/agent-test/testdata/effect/default.nix
@@ -1,0 +1,26 @@
+{ src ? null }:
+{
+  herculesCI.onPush.cd = {
+    inputs =
+      # {
+      #   nixpkgs = {
+      #     project = "nixpkgs";
+      #   };
+      # };
+      throw "not part of the test (but could be if needed)";
+
+    outputs = { nixpkgs, ... }:
+      let pkgs = import nixpkgs {};
+      in {
+        effects.launchIt = pkgs.runCommand "one" {
+          t = builtins.currentTime;
+        } ''
+          echo 1>&2 hello "on stderr"
+          echo hello "on stdout"
+          cat ${builtins.toFile "the-src" "hi from src\n"}
+
+          echo -n log line "without newline"
+        '' // { isEffect = true; };
+      };
+  };
+}

--- a/tests/agent-test/testdata/effect/default.nix
+++ b/tests/agent-test/testdata/effect/default.nix
@@ -14,10 +14,17 @@
       in {
         effects.launchIt = pkgs.runCommand "one" {
           t = builtins.currentTime;
+          __hci_mounts = builtins.toJSON {
+            "/etc/forwarded-path" = "forwarded-path";
+            "/var/lib/shared-data" = "shared-data";
+          };
         } ''
           echo 1>&2 hello "on stderr"
           echo hello "on stdout"
           cat ${builtins.toFile "the-src" "hi from src\n"}
+          cat /etc/forwarded-path/hello
+          echo 'hello from shared-data' > /var/lib/shared-data/hello
+          cat /var/lib/shared-data/hello
 
           echo -n log line "without newline"
         '' // { isEffect = true; };

--- a/tests/agent-test/testdata/effect/default.nix
+++ b/tests/agent-test/testdata/effect/default.nix
@@ -14,9 +14,11 @@
       in {
         effects.launchIt = pkgs.runCommand "one" {
           t = builtins.currentTime;
+          nativeBuildInputs = [ pkgs.curl ];
           __hci_mounts = builtins.toJSON {
             "/etc/forwarded-path" = "forwarded-path";
             "/var/lib/shared-data" = "shared-data";
+            "/etc/hosts" = "hosts";
           };
         } ''
           echo 1>&2 hello "on stderr"
@@ -25,6 +27,11 @@
           cat /etc/forwarded-path/hello
           echo 'hello from shared-data' > /var/lib/shared-data/hello
           cat /var/lib/shared-data/hello
+
+          cat /etc/resolv.conf
+          cat /etc/hosts
+          curl --fail -v --no-progress-bar \
+              $HERCULES_CI_API_BASE_URL/hello
 
           echo -n log line "without newline"
         '' // { isEffect = true; };


### PR DESCRIPTION
Effect mounts. Specify effectMountables in the agent configuration, deploy, and mount them into an effect. This can be used for instance to expose the host's /etc/hosts, or hardware devices such as GPUs. Access is controlled by the agent configuration.