### PR TITLE
fix: Avoid s.c_str()

### DIFF
--- a/hercules-ci-agent/cbits/hercules-error.cxx
+++ b/hercules-ci-agent/cbits/hercules-error.cxx
@@ -1,4 +1,7 @@
 #include "hercules-error.hh"
+#include "hercules-ci-cnix/string.hxx"
+
+using namespace hercules_ci_cnix;
 
 void
 hercules::copyErrorStrings(const nix::Error &err, const char **msgStrPtr, const char **traceStrPtr) noexcept {
@@ -7,7 +10,7 @@ hercules::copyErrorStrings(const nix::Error &err, const char **msgStrPtr, const 
         std::stringstream s;
         nix::showErrorInfo(s, err.info(), false);
         msg = s.str();
-        *msgStrPtr = strdup(msg.c_str());
+        *msgStrPtr = stringdup(msg);
     }
 
     // There's no method for getting just the trace, short of
@@ -24,6 +27,6 @@ hercules::copyErrorStrings(const nix::Error &err, const char **msgStrPtr, const 
             t = nix::trim(t);
         }
 
-        *traceStrPtr = strdup(t.c_str());
+        *traceStrPtr = stringdup(t);
     }
 }

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Logger.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Logger.hs
@@ -39,11 +39,15 @@ C.include "<nix/shared.hh>"
 
 C.include "<nix/globals.hh>"
 
+C.include "<hercules-ci-cnix/string.hxx>"
+
 C.include "hercules-aliases.h"
 
 C.include "hercules-logger.hh"
 
 C.using "namespace nix"
+
+C.using "namespace hercules_ci_cnix"
 
 initLogger :: IO ()
 initLogger =
@@ -130,11 +134,11 @@ convertEntry logEntryPtr = alloca \millisPtr -> alloca \textStrPtr -> alloca \le
         *$(uint64_t *millisPtr) = ln.ms;
         switch (ln.entryType) {
           case 1:
-            *$(const char **textStrPtr) = strdup(ln.text.c_str());
+            *$(const char **textStrPtr) = stringdup(ln.text);
             *$(int *levelPtr) = ln.level;
             return ln.entryType;
           case 2:
-            *$(const char **textStrPtr) = strdup(ln.text.c_str());
+            *$(const char **textStrPtr) = stringdup(ln.text);
             *$(int *levelPtr) = ln.level;
             *$(uint64_t *activityIdPtr) = ln.activityId;
             *$(uint64_t *typePtr) = ln.type;
@@ -224,7 +228,7 @@ convertAndDeleteFields fieldsPtr = flip
             *$(uint64_t *uintPtr) = field.i;
             return 0;
           case nix::Logger::Field::tString:
-            *$(const char **stringPtr) = strdup(field.s.c_str());
+            *$(const char **stringPtr) = stringdup(field.s);
             return 1;
           default:
             return -1;

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Prefetched.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/Build/Prefetched.hs
@@ -53,7 +53,11 @@ C.include "<nix/path-with-outputs.hh>"
 
 C.include "<hercules-ci-cnix/store.hxx>"
 
+C.include "<hercules-ci-cnix/string.hxx>"
+
 C.using "namespace nix"
+
+C.using "namespace hercules_ci_cnix"
 
 data BuildStatus
   = Built
@@ -166,7 +170,7 @@ buildDerivation (Store store) derivationPath derivation extraInputs =
           printError(e.msg());
           status = -2;
           success = false;
-          errorMessage = strdup(e.msg().c_str());
+          errorMessage = stringdup(e.msg());
           startTime = 0;
           stopTime = 0;
         }
@@ -230,7 +234,7 @@ buildDerivation (Store store) derivationPath derivation extraInputs =
         }
         printError(result.errorMsg);
         success = result.success();
-        errorMessage = strdup(result.errorMsg.c_str());
+        errorMessage = stringdup(result.errorMsg);
         startTime = result.startTime;
         stopTime = result.stopTime;
       }

--- a/hercules-ci-cnix-expr/src/Hercules/CNix/Expr.hs
+++ b/hercules-ci-cnix-expr/src/Hercules/CNix/Expr.hs
@@ -133,6 +133,8 @@ C.include "<nix/args/root.hh>"
 
 C.include "hercules-ci-cnix/expr.hxx"
 
+C.include "hercules-ci-cnix/string.hxx"
+
 C.include "<gc/gc.h>"
 
 C.include "<gc/gc_cpp.h>"
@@ -140,6 +142,8 @@ C.include "<gc/gc_cpp.h>"
 C.include "<gc/gc_allocator.h>"
 
 C.using "namespace nix"
+
+C.using "namespace hercules_ci_cnix"
 
 C.verbatim "\nGC_API void GC_CALL GC_throw_bad_alloc() { throw std::bad_alloc(); }\n"
 
@@ -464,10 +468,10 @@ getAttrs evalState (Value (RawValue v)) = do
         name <- unsafeMallocBS [C.block| const char *{
           EvalState &evalState = *$(EvalState *evalState);
           SymbolStr str = evalState.symbols[$(Attr *i)->name];
-          return strdup(static_cast<std::string>(str).c_str());
+          return stringdup(static_cast<std::string>(str));
         }|]
 #else
-        name <- unsafeMallocBS [C.exp| const char *{ strdup(static_cast<std::string>($(Attr *i)->name).c_str()) } |]
+        name <- unsafeMallocBS [C.exp| const char *{ stringdup(static_cast<std::string>($(Attr *i)->name)) } |]
 #endif
         value <- mkRawValue =<< [C.exp| Value *{ new (NoGC) Value(*$(Attr *i)->value) } |]
         let acc' = M.insert name value acc
@@ -587,7 +591,7 @@ mkPath evalState path =
 #if NIX_IS_AT_LEAST(2,19,0)
       r->mkPath(state.rootPath(CanonPath(s)));
 #else
-      r->mkPath(s.c_str());
+      r->mkPath(stringdup(s));
 #endif
       return r;
   }|]

--- a/hercules-ci-cnix-store/cbits/string.cxx
+++ b/hercules-ci-cnix-store/cbits/string.cxx
@@ -1,0 +1,12 @@
+#include "hercules-ci-cnix/string.hxx"
+
+namespace hercules_ci_cnix {
+
+char * stringdup(const std::string & s) {
+    char * p = (char *)malloc(s.size() + 1);
+    std::copy(s.begin(), s.end(), p);
+    p[s.size()] = '\0';
+    return p;
+}
+
+} // namespace hercules_ci_cnix

--- a/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
+++ b/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
@@ -43,6 +43,8 @@ common cxx-opts
 
   cxx-options:
     -Wall
+    -- GHC does _not_ produce declarations, so this only applies to cxx-sources.
+    -Werror=missing-declarations
   extra-libraries: stdc++
 
   if os(darwin)
@@ -96,7 +98,10 @@ library
     , nix-main >= 2.4 && < 2.19 || (>= 2.19.3 && < 2.21)
   install-includes:
       hercules-ci-cnix/store.hxx
+      hercules-ci-cnix/string.hxx
   hs-source-dirs: src
+  cxx-sources:
+      cbits/string.cxx
   build-depends:
       base >= 4.7 && <5
     , inline-c

--- a/hercules-ci-cnix-store/include/hercules-ci-cnix/string.hxx
+++ b/hercules-ci-cnix-store/include/hercules-ci-cnix/string.hxx
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+
+namespace hercules_ci_cnix {
+
+/**
+  c_str() on a std::string only works if the std::string doesn't go out of scope.
+  `stringdup` is like `strdup(s.c_str())`, but without the undefined behavior.
+ */
+char * stringdup(const std::string & s);
+
+} // namespace hercules_ci_cnix

--- a/hercules-ci-cnix-store/src/Hercules/CNix.hs
+++ b/hercules-ci-cnix-store/src/Hercules/CNix.hs
@@ -59,7 +59,11 @@ C.include "<gc/gc_cpp.h>"
 
 C.include "<gc/gc_allocator.h>"
 
+C.include "hercules-ci-cnix/string.hxx"
+
 C.using "namespace nix"
+
+C.using "namespace hercules_ci_cnix"
 
 init :: IO ()
 init =
@@ -107,7 +111,7 @@ nixVersion :: ByteString
 nixVersion = unsafePerformIO $ do
   p <-
     [C.exp| const char* {
-      strdup(nix::nixVersion.c_str())
+      stringdup(nix::nixVersion)
     }|]
   unsafePackMallocCString p
 {-# NOINLINE nixVersion #-}

--- a/hercules-ci-cnix-store/src/Hercules/CNix/Settings.hs
+++ b/hercules-ci-cnix-store/src/Hercules/CNix/Settings.hs
@@ -40,6 +40,9 @@ C.include "<nix/config.h>"
 C.include "<nix/globals.hh>"
 C.include "<set>"
 C.include "<string>"
+C.include "hercules-ci-cnix/string.hxx"
+
+C.using "namespace hercules_ci_cnix"
 
 byteStringSet :: IO (Ptr (Std.Set.CStdSet Std.String.CStdString)) -> IO (Set ByteString)
 byteStringSet x =
@@ -67,7 +70,7 @@ getSystem :: IO ByteString
 getSystem =
   unsafePackMallocCString
     =<< [C.exp| const char *{
-      strdup(nix::settings.thisSystem.get().c_str())
+      stringdup(nix::settings.thisSystem.get())
     }|]
 
 getSystemFeatures :: IO (Set ByteString)
@@ -107,7 +110,7 @@ getNetrcFile :: IO ByteString
 getNetrcFile =
   unsafePackMallocCString
     =<< [C.exp| const char *{
-      strdup(nix::settings.netrcFile.get().c_str())
+      stringdup(nix::settings.netrcFile.get())
     }|]
 
 -- Gets the value of https://nixos.org/manual/nix/stable/command-ref/conf-file.html?highlight=use-sqlite-wal#conf-use-sqlite-wal


### PR DESCRIPTION
s.c_str() is only defined while s is in scope. Fine for variables, but unassigned return values cause undefined behavior.

This gets rid of almost all of the c_str() calls. A few remain, and those have been checked for this problem and are ok.

(cherry picked from commit 072da9a4a5e3638fabd458633408d5f16b5ba87f)