### PR TITLE
Migrate to C API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,6 +35,39 @@
         "type": "github"
       }
     },
+    "hs-bindgen": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1763740177,
+        "narHash": "sha256-tyEDNLCBb2jJhBJ478MG+QD2yhOWzbi1Sm3jS5oTmn0=",
+        "owner": "hercules-ci",
+        "repo": "hs-bindgen",
+        "rev": "4eb901ee196b81d39d67755ac62343e263b6519e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "ref": "avoid-template-haskell",
+        "repo": "hs-bindgen",
+        "type": "github"
+      }
+    },
+    "libclang-bindings": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1763640650,
+        "narHash": "sha256-ZUWm6FX9Dgt/e/DN9k8NfdZkoZIIvfh4HYfdN/0tdEE=",
+        "owner": "well-typed",
+        "repo": "libclang",
+        "rev": "b62972c5a4227f92ac7af7df60af52f9ead7bd35",
+        "type": "github"
+      },
+      "original": {
+        "owner": "well-typed",
+        "repo": "libclang",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1759036355,
@@ -55,6 +88,8 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
+        "hs-bindgen": "hs-bindgen",
+        "libclang-bindings": "libclang-bindings",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/HerculesStore.hs
+++ b/hercules-ci-agent/hercules-ci-agent-worker/Hercules/Agent/Worker/HerculesStore.hs
@@ -38,6 +38,12 @@ C.include "<cstring>"
 
 C.include "hercules-aliases.h"
 
+-- C API internals header to access C++ Store from C API Store
+C.include "<nix_api_store_internal.h>"
+
+-- Create a typedef to disambiguate C API Store from nix::Store
+C.verbatim "typedef ::Store nix_store;"
+
 C.using "namespace nix"
 
 withHerculesStore ::
@@ -48,7 +54,7 @@ withHerculesStore (Store wrappedStore) =
   bracket
     ( liftIO
         [C.block| refHerculesStore* {
-          refStore &s = *$(refStore *wrappedStore);
+          refStore &s = $(nix_store *wrappedStore)->ptr;
           refHerculesStore hs(new HerculesStore(s));
           return new refHerculesStore(hs);
         } |]

--- a/hercules-ci-cnix-store/.gitignore
+++ b/hercules-ci-cnix-store/.gitignore
@@ -1,0 +1,1 @@
+src-generated/

--- a/hercules-ci-cnix-store/Setup.hs
+++ b/hercules-ci-cnix-store/Setup.hs
@@ -1,13 +1,43 @@
 import Data.Function ((&))
 import Distribution.PkgConfigVersionHook as PV
 import Distribution.Simple
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+import System.Directory (createDirectoryIfMissing)
+import System.Process (callProcess)
 
 main :: IO ()
 main =
   defaultMainWithHooks $
     simpleUserHooks
+      { preBuild = \args flags -> do
+          generateBindings (fromFlag $ buildVerbosity flags)
+          preBuild simpleUserHooks args flags
+      }
       & PV.addHook
         (PV.mkSettings "nix-store")
           { PV.macroName = "NIX",
             PV.flagPrefixName = "nix"
           }
+
+generateBindings :: Verbosity -> IO ()
+generateBindings verbosity = do
+  notice verbosity "Generating Nix C API bindings with hs-bindgen..."
+  createDirectoryIfMissing True "src-generated"
+  callProcess
+    "hs-bindgen-cli"
+    [ "preprocess",
+      "-I",
+      "/nix/store/3bgmbyiinaq8z420gjg8bz2pqf0dpzyp-nix-2.28.5-dev/include",
+      "--hs-output-dir",
+      "src-generated",
+      "--create-output-dirs",
+      "--module",
+      "Hercules.CNix.Nix.API.Store",
+      "--unique-id",
+      "com.hercules-ci.cnix-store",
+      "--enable-program-slicing",
+      "/nix/store/3bgmbyiinaq8z420gjg8bz2pqf0dpzyp-nix-2.28.5-dev/include/nix_api_store.h"
+    ]

--- a/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
+++ b/hercules-ci-cnix-store/hercules-ci-cnix-store.cabal
@@ -56,6 +56,8 @@ custom-setup
     base < 5
     , Cabal >= 2.2.0.0 && < 4
     , cabal-pkg-config-version-hook
+    , directory
+    , process
 
 library
   import: cxx-opts
@@ -75,15 +77,26 @@ library
       Hercules.CNix.Store.Instances
       Hercules.CNix.Util
       Hercules.CNix.Verbosity
+  other-modules:
+      Hercules.CNix.Nix.API.Store
+      Hercules.CNix.Nix.API.Store.Safe
+      Hercules.CNix.Nix.API.Store.Unsafe
+      -- Hercules.CNix.Nix.API.Store.FunPtr omitted: uses TH to provide function pointers, which we don't need
+  autogen-modules:
+      Hercules.CNix.Nix.API.Store
+      Hercules.CNix.Nix.API.Store.Safe
+      Hercules.CNix.Nix.API.Store.Unsafe
+      -- Hercules.CNix.Nix.API.Store.FunPtr omitted: uses TH to provide function pointers, which we don't need
   include-dirs:
       include
       cbits
   pkgconfig-depends:
       nix-store >= 2.28 && < 2.31
+    , nix-store-c >= 2.28 && < 2.31
   install-includes:
       hercules-ci-cnix/store.hxx
       hercules-ci-cnix/string.hxx
-  hs-source-dirs: src
+  hs-source-dirs: src src-generated
   cxx-sources:
       cbits/string.cxx
       cbits/signals.cxx
@@ -100,6 +113,8 @@ library
     , unix
     , unliftio-core
     , vector
+    , hs-bindgen-runtime
+    , c-expr-runtime
   if ! flag(ide)
     extra-libraries:
       boost_context

--- a/hercules-ci-cnix-store/src/Hercules/CNix/Store/Context.hs
+++ b/hercules-ci-cnix-store/src/Hercules/CNix/Store/Context.hs
@@ -7,6 +7,8 @@ module Hercules.CNix.Store.Context where
 import Data.ByteString.Unsafe (unsafePackMallocCString)
 import qualified Data.Map as M
 import qualified Foreign.C.String
+-- Import C API Store type for inline-c context
+import qualified Hercules.CNix.Nix.API.Store as CAPI
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Types as C
@@ -52,7 +54,8 @@ context =
     <> C.bsCtx
     <> mempty
       { C.ctxTypesTable =
-          M.singleton (C.TypeName "refStore") [t|Ref NixStore|]
+          M.singleton (C.TypeName "nix_store") [t|CAPI.Store|]
+            <> M.singleton (C.TypeName "refStore") [t|Ref NixStore|]
             <> M.singleton (C.TypeName "nix::StorePath") [t|NixStorePath|]
             <> M.singleton (C.TypeName "nix::StorePathWithOutputs") [t|NixStorePathWithOutputs|]
             <> M.singleton (C.TypeName "refValidPathInfo") [t|Ref ValidPathInfo|]


### PR DESCRIPTION
Goals
- Get rid of Template Haskell, which remains problematic for tooling reasons
- Use a more stable API necessitating fewer compatibility updates

TODO
- [x] generate code and use C API store type
- [ ] more testing
- [ ] get upstream `hs-bindgen` to emit no TH (see branch)
- [ ] figure out interrupts without `ReceiveInterrupts _;`
- [ ] migrate all calls
- [ ] migrate calls that require custom C code
- [ ] make `hs-bindgen` available in Nixpkgs
- [ ] follow-up: upstream custom C code to become part of C API (and polyfilling until available)

TH trouble:
- https://github.com/NixOS/nixpkgs/issues/461651#issuecomment-3536203369
- https://github.com/cachix/cachix/issues/627
